### PR TITLE
chore: address some `clippy` lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,5 +2,5 @@
 resolver = "2"
 members = ["crates/*"]
 package.edition = "2021"
-package.license = "Apache-2.0"
+package.license = "AGPL-3.0-or-later"
 package.version = "0.1.0"

--- a/crates/location_tracking_service/src/common/geo_polygon.rs
+++ b/crates/location_tracking_service/src/common/geo_polygon.rs
@@ -49,15 +49,11 @@ fn parse_geojson_multi_polygon(region: &str, geojson_str: &str) -> Result<MultiP
     let geom: Geometry = from_str(geojson_str)?;
 
     match geom.value {
-        Value::MultiPolygon(multi_polygon) => {
-            return Ok(create_multipolygon_body(region, multi_polygon))
-        }
-        _ => {
-            return Err(io::Error::new(
-                io::ErrorKind::Other,
-                "GeoJSON is not a valid MultiPolygon.",
-            ))
-        }
+        Value::MultiPolygon(multi_polygon) => Ok(create_multipolygon_body(region, multi_polygon)),
+        _ => Err(io::Error::new(
+            io::ErrorKind::Other,
+            "GeoJSON is not a valid MultiPolygon.",
+        )),
     }
 }
 
@@ -72,7 +68,7 @@ pub fn to_multipolygon(polygons: Vec<PolygonType>) -> MultiPolygon<f64> {
     MultiPolygon::new(
         polygons
             .into_iter()
-            .map(|polygon| to_polygon(polygon))
+            .map(to_polygon)
             .collect::<Vec<Polygon<f64>>>(),
     )
 }
@@ -81,7 +77,7 @@ fn to_polygon(polygon: Vec<Vec<Position>>) -> Polygon<f64> {
     Polygon::new(
         polygon
             .into_iter()
-            .map(|line_string: Vec<Position>| to_line_string(line_string))
+            .map(to_line_string)
             .collect::<Vec<LineString<f64>>>()
             .into_iter()
             .flatten()
@@ -94,7 +90,7 @@ fn to_line_string(line_string: Vec<Position>) -> LineString<f64> {
     LineString::new(
         line_string
             .into_iter()
-            .map(|position: Position| to_coord(position))
+            .map(to_coord)
             .collect::<Vec<Coord<f64>>>(),
     )
 }

--- a/crates/location_tracking_service/src/common/types.rs
+++ b/crates/location_tracking_service/src/common/types.rs
@@ -145,6 +145,7 @@ pub struct AppState {
     pub non_persistent_redis: Arc<RedisConnectionPool>,
     pub persistent_redis: Arc<RedisConnectionPool>,
     pub drainer_delay: u64,
+    #[allow(clippy::type_complexity)]
     pub queue: Arc<Mutex<HashMap<Dimensions, Vec<(Latitude, Longitude, DriverId)>>>>,
     pub polygon: Vec<MultiPolygonBody>,
     pub auth_url: String,

--- a/crates/location_tracking_service/src/domain/action/internal/location.rs
+++ b/crates/location_tracking_service/src/domain/action/internal/location.rs
@@ -56,9 +56,9 @@ async fn search_nearby_drivers_with_vehicle(
             driver_id: driver.driver_id.to_string(),
             lat: driver.location.lat,
             lon: driver.location.lon,
-            coordinates_calculated_at: timestamp.clone(),
-            created_at: timestamp.clone(),
-            updated_at: timestamp.clone(),
+            coordinates_calculated_at: timestamp,
+            created_at: timestamp,
+            updated_at: timestamp,
             merchant_id: merchant_id.clone(),
         };
         resp.push(driver_location);
@@ -91,7 +91,7 @@ pub async fn get_nearby_drivers(
                         lon: request_body.clone().lon,
                     },
                     request_body.clone().radius,
-                    request_body.on_ride.unwrap_or_else(|| false),
+                    request_body.on_ride.unwrap_or(false),
                 )
                 .await;
                 match nearby_drivers {
@@ -118,7 +118,7 @@ pub async fn get_nearby_drivers(
                     lon: request_body.clone().lon,
                 },
                 request_body.clone().radius,
-                request_body.on_ride.unwrap_or_else(|| false),
+                request_body.on_ride.unwrap_or(false),
             )
             .await?;
             Ok(resp)

--- a/crates/location_tracking_service/src/domain/action/internal/location.rs
+++ b/crates/location_tracking_service/src/domain/action/internal/location.rs
@@ -19,6 +19,7 @@ use crate::{
 };
 use shared::{tools::error::AppError, utils::logger::*};
 
+#[allow(clippy::too_many_arguments)]
 async fn search_nearby_drivers_with_vehicle(
     data: Data<AppState>,
     merchant_id: MerchantId,

--- a/crates/location_tracking_service/src/domain/action/internal/ride.rs
+++ b/crates/location_tracking_service/src/domain/action/internal/ride.rs
@@ -23,20 +23,20 @@ async fn update_driver_location(
     lon: Longitude,
     driver_mode: Option<DriverMode>,
 ) -> Result<(), AppError> {
-    let _ = set_driver_last_location_update(
+    set_driver_last_location_update(
         data.clone(),
-        &driver_id,
-        &merchant_id,
+        driver_id,
+        merchant_id,
         &Point { lat, lon },
         driver_mode,
     )
     .await?;
 
-    let _ = push_on_ride_driver_location(
+    push_on_ride_driver_location(
         data,
-        &driver_id,
-        &merchant_id,
-        &city,
+        driver_id,
+        merchant_id,
+        city,
         &vec![Point { lat, lon }],
     )
     .await?;
@@ -70,7 +70,7 @@ pub async fn ride_start(
     )
     .await?;
 
-    let _ = update_driver_location(
+    update_driver_location(
         data.clone(),
         &request_body.driver_id,
         &request_body.merchant_id,
@@ -110,7 +110,7 @@ pub async fn ride_end(
     )
     .await?;
 
-    let _ = update_driver_location(
+    update_driver_location(
         data.clone(),
         &request_body.driver_id,
         &request_body.merchant_id,
@@ -139,7 +139,7 @@ pub async fn ride_end(
     .await?;
 
     Ok(RideEndResponse {
-        ride_id: ride_id,
+        ride_id,
         driver_id: request_body.driver_id,
         loc: on_ride_driver_locations,
     })
@@ -177,7 +177,7 @@ pub async fn ride_details(
     )
     .await?;
 
-    let _ = update_driver_location(
+    update_driver_location(
         data.clone(),
         &request_body.driver_id,
         &request_body.merchant_id,

--- a/crates/location_tracking_service/src/domain/action/ui/location.rs
+++ b/crates/location_tracking_service/src/domain/action/ui/location.rs
@@ -56,10 +56,7 @@ async fn kafka_stream_updates(
             lat: loc.pt.lat,
             lon: loc.pt.lon,
         },
-        acc: match loc.acc {
-            Some(acc) => acc,
-            None => 0,
-        },
+        acc: loc.acc.unwrap_or(0),
         ride_status: ride_status.to_string(),
         da: true,
         mode: driver_mode.to_string(),
@@ -176,7 +173,7 @@ async fn process_driver_locations(
         lon: driver_location.pt.lon,
     };
 
-    let _ = set_driver_last_location_update(
+    set_driver_last_location_update(
         data.clone(),
         &driver_id,
         &merchant_id,
@@ -243,7 +240,7 @@ async fn process_driver_locations(
                 .await;
             }
 
-            let _ = push_on_ride_driver_location(
+            push_on_ride_driver_location(
                 data.clone(),
                 &driver_id,
                 &merchant_id,

--- a/crates/location_tracking_service/src/domain/api/ui/location.rs
+++ b/crates/location_tracking_service/src/domain/api/ui/location.rs
@@ -38,14 +38,14 @@ pub async fn update_driver_location(
         .headers()
         .get("token")
         .and_then(|header_value| header_value.to_str().ok())
-        .and_then(|dm_str| Some(dm_str.to_string()))
+        .map(|dm_str| dm_str.to_string())
         .ok_or(AppError::InvalidRequest("Token not found".to_string()))?;
 
     let merchant_id = req
         .headers()
         .get("mId")
         .and_then(|header_value| header_value.to_str().ok())
-        .and_then(|dm_str| Some(dm_str.to_string()))
+        .map(|dm_str| dm_str.to_string())
         .ok_or(AppError::InvalidRequest("mId not found".to_string()))?;
 
     let vehicle_type = req

--- a/crates/location_tracking_service/src/main.rs
+++ b/crates/location_tracking_service/src/main.rs
@@ -39,7 +39,7 @@ impl RootSpanBuilder for DomainRootSpanBuilder {
     fn on_request_start(request: &ServiceRequest) -> Span {
         let request_id = request.headers().get("x-request-id");
         let request_id = match request_id {
-            Some(request_id) => request_id.to_str().and_then(|str| Ok(str.to_string())),
+            Some(request_id) => request_id.to_str().map(|str| str.to_string()),
             None => Ok(Uuid::new_v4().to_string()),
         }
         .unwrap_or(Uuid::new_v4().to_string());

--- a/crates/location_tracking_service/src/redis/commands.rs
+++ b/crates/location_tracking_service/src/redis/commands.rs
@@ -31,7 +31,7 @@ pub async fn set_ride_details(
 
     data.persistent_redis
         .set_with_expiry(
-            &on_ride_details_key(&merchant_id, &city, &driver_id),
+            &on_ride_details_key(merchant_id, city, driver_id),
             ride_details,
             data.redis_expiry,
         )
@@ -74,8 +74,7 @@ pub async fn get_drivers_within_radius(
         let nearby_drivers_by_bucket = data
             .non_persistent_redis
             .geo_search(
-                driver_loc_bucket_key(&merchant_id, &city, &vehicle, &(bucket - bucket_idx))
-                    .as_str(),
+                driver_loc_bucket_key(merchant_id, city, vehicle, &(bucket - bucket_idx)).as_str(),
                 None,
                 Some(GeoPosition::from((location.lon, location.lat))),
                 Some((radius, GeoUnit::Meters)),
@@ -117,7 +116,7 @@ pub async fn get_drivers_within_radius(
                         {
                             resp.push(DriverLocationPoint {
                                 driver_id: driver_id.to_string(),
-                                location: Point { lat: lat, lon: lon },
+                                location: Point { lat, lon },
                             });
                         }
                     }
@@ -150,13 +149,13 @@ pub async fn get_drivers_within_radius(
                         {
                             resp.push(DriverLocationPoint {
                                 driver_id: driver_id.to_string(),
-                                location: Point { lat: lat, lon: lon },
+                                location: Point { lat, lon },
                             });
                         }
                     } else {
                         resp.push(DriverLocationPoint {
                             driver_id: driver_id.to_string(),
-                            location: Point { lat: lat, lon: lon },
+                            location: Point { lat, lon },
                         });
                     }
                 }
@@ -166,7 +165,7 @@ pub async fn get_drivers_within_radius(
             }
         }
     }
-    return Ok(resp);
+    Ok(resp)
 }
 
 pub async fn push_drainer_driver_location(
@@ -175,17 +174,16 @@ pub async fn push_drainer_driver_location(
     city: &CityName,
     vehicle: &VehicleType,
     bucket: &u64,
-    geo_entries: &Vec<(Latitude, Longitude, DriverId)>,
+    geo_entries: &[(Latitude, Longitude, DriverId)],
 ) -> Result<(), AppError> {
     let geo_values: Vec<GeoValue> = geo_entries
-        .to_owned()
-        .into_iter()
+        .iter()
         .map(|(lat, lon, driver_id)| {
             prometheus::QUEUE_GUAGE.dec();
             GeoValue {
                 coordinates: GeoPosition {
-                    latitude: lat,
-                    longitude: lon,
+                    latitude: *lat,
+                    longitude: *lon,
                 },
                 member: driver_id.into(),
             }
@@ -193,8 +191,7 @@ pub async fn push_drainer_driver_location(
         .collect();
     let multiple_geo_values: MultipleGeoValues = geo_values.into();
 
-    let _ = data
-        .non_persistent_redis
+    data.non_persistent_redis
         .geo_add_with_expiry(
             &driver_loc_bucket_key(merchant_id, city, vehicle, bucket),
             multiple_geo_values,
@@ -204,7 +201,7 @@ pub async fn push_drainer_driver_location(
         )
         .await?;
 
-    return Ok(());
+    Ok(())
 }
 
 pub async fn get_driver_location(
@@ -213,7 +210,7 @@ pub async fn get_driver_location(
 ) -> Result<DriverLastKnownLocation, AppError> {
     let last_location_update = data
         .persistent_redis
-        .get_key(&driver_details_key(&driver_id))
+        .get_key(&driver_details_key(driver_id))
         .await?;
 
     if let Some(val) = last_location_update {
@@ -224,9 +221,9 @@ pub async fn get_driver_location(
         }
     }
 
-    return Err(AppError::InternalError(
+    Err(AppError::InternalError(
         "Failed to get_driver_location".to_string(),
-    ));
+    ))
 }
 
 pub async fn get_driver_last_location_update(
@@ -235,7 +232,7 @@ pub async fn get_driver_last_location_update(
 ) -> Result<DateTime<Utc>, AppError> {
     let last_location_update = data
         .persistent_redis
-        .get_key(&driver_details_key(&driver_id))
+        .get_key(&driver_details_key(driver_id))
         .await?;
 
     if let Some(val) = last_location_update {
@@ -246,9 +243,9 @@ pub async fn get_driver_last_location_update(
         }
     }
 
-    return Err(AppError::InternalError(
+    Err(AppError::InternalError(
         "Failed to get_driver_last_location_update".to_string(),
-    ));
+    ))
 }
 
 pub async fn set_driver_mode_details(
@@ -273,15 +270,14 @@ pub async fn set_driver_mode_details(
     };
     let value = serde_json::to_string(&driver_all_details)
         .map_err(|err| AppError::InternalError(err.to_string()))?;
-    let _ = data
-        .persistent_redis
+    data.persistent_redis
         .set_with_expiry(
             &driver_details_key(&driver_id),
             value,
             data.last_location_timstamp_expiry,
         )
         .await?;
-    return Ok(());
+    Ok(())
 }
 
 pub async fn set_driver_last_location_update(
@@ -293,7 +289,7 @@ pub async fn set_driver_last_location_update(
 ) -> Result<(), AppError> {
     let last_location_update = data
         .persistent_redis
-        .get_key(&driver_details_key(&driver_id))
+        .get_key(&driver_details_key(driver_id))
         .await?;
 
     let driver_all_details = if let Some(val) = last_location_update {
@@ -314,7 +310,7 @@ pub async fn set_driver_last_location_update(
         }
         value
     } else {
-        let value = DriverAllDetails {
+        DriverAllDetails {
             driver_mode,
             driver_last_known_location: Some(DriverLastKnownLocation {
                 location: Point {
@@ -324,22 +320,20 @@ pub async fn set_driver_last_location_update(
                 timestamp: Utc::now(),
                 merchant_id: merchant_id.to_string(),
             }),
-        };
-        value
+        }
     };
     let value = serde_json::to_string(&driver_all_details)
         .map_err(|err| AppError::InternalError(err.to_string()))?;
 
-    let _ = data
-        .persistent_redis
+    data.persistent_redis
         .set_with_expiry(
-            &driver_details_key(&driver_id),
+            &driver_details_key(driver_id),
             value,
             data.last_location_timstamp_expiry,
         )
         .await?;
 
-    return Ok(());
+    Ok(())
 }
 
 pub async fn get_driver_ride_status(
@@ -350,7 +344,7 @@ pub async fn get_driver_ride_status(
 ) -> Result<Option<RideStatus>, AppError> {
     let ride_details: Option<String> = data
         .persistent_redis
-        .get_key(&on_ride_details_key(&merchant_id, &city, &driver_id))
+        .get_key(&on_ride_details_key(merchant_id, city, driver_id))
         .await?;
 
     match ride_details {
@@ -372,7 +366,7 @@ pub async fn get_driver_ride_details(
 ) -> Result<RideDetails, AppError> {
     let ride_details: Option<String> = data
         .persistent_redis
-        .get_key(&on_ride_details_key(&merchant_id, &city, &driver_id))
+        .get_key(&on_ride_details_key(merchant_id, city, driver_id))
         .await?;
 
     let ride_details = match ride_details {
@@ -396,7 +390,7 @@ pub async fn get_driver_details(
 ) -> Result<DriverDetails, AppError> {
     let driver_details: Option<String> = data
         .persistent_redis
-        .get_key(&on_ride_driver_details_key(&ride_id))
+        .get_key(&on_ride_driver_details_key(ride_id))
         .await?;
 
     let driver_details = match driver_details {
@@ -431,13 +425,10 @@ pub async fn push_on_ride_driver_location(
 
     let _ = data
         .persistent_redis
-        .rpush(
-            &on_ride_loc_key(&merchant_id, &city, &driver_id),
-            geo_points,
-        )
+        .rpush(&on_ride_loc_key(merchant_id, city, driver_id), geo_points)
         .await?;
 
-    return Ok(());
+    Ok(())
 }
 
 pub async fn get_on_ride_driver_location_count(
@@ -448,7 +439,7 @@ pub async fn get_on_ride_driver_location_count(
 ) -> Result<i64, AppError> {
     let driver_location_count = data
         .persistent_redis
-        .llen(&on_ride_loc_key(&merchant_id, &city, &driver_id))
+        .llen(&on_ride_loc_key(merchant_id, city, driver_id))
         .await?;
 
     Ok(driver_location_count)
@@ -464,7 +455,7 @@ pub async fn get_on_ride_driver_locations(
     let output = data
         .persistent_redis
         .rpop(
-            &on_ride_loc_key(&merchant_id, &city, &driver_id),
+            &on_ride_loc_key(merchant_id, city, driver_id),
             Some(pop_length),
         )
         .await?;
@@ -519,7 +510,7 @@ where
 {
     let lock = redis.setnx_with_expiry(key, true, expiry).await;
 
-    if let Ok(_) = lock {
+    if lock.is_ok() {
         let resp = callback(args).await;
         let _ = redis.delete_key(key).await;
         resp?

--- a/crates/location_tracking_service/src/redis/commands.rs
+++ b/crates/location_tracking_service/src/redis/commands.rs
@@ -59,6 +59,7 @@ pub async fn set_driver_details(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn get_drivers_within_radius(
     data: Data<AppState>,
     merchant_id: &MerchantId,

--- a/crates/location_tracking_service/src/redis/keys.rs
+++ b/crates/location_tracking_service/src/redis/keys.rs
@@ -28,7 +28,7 @@ pub fn driver_details_key(driver_id: &DriverId) -> String {
 
 // Persistent Redis
 pub fn health_check_key() -> String {
-    format!("lts:health_check")
+    "lts:health_check".to_string()
 }
 
 // Persistent Redis

--- a/crates/shared/src/mod.rs
+++ b/crates/shared/src/mod.rs
@@ -1,3 +1,0 @@
-pub mod redis;
-pub mod tools;
-pub mod utils;

--- a/crates/shared/src/redis/commands.rs
+++ b/crates/shared/src/redis/commands.rs
@@ -218,11 +218,8 @@ impl RedisConnectionPool {
             Ok(RedisValue::Array(val)) => {
                 let mut values = Vec::new();
                 for value in val {
-                    match value {
-                        RedisValue::String(y) => {
-                            values.push(String::from_utf8(y.into_inner().to_vec()).unwrap())
-                        }
-                        _ => (),
+                    if let RedisValue::String(y) = value {
+                        values.push(String::from_utf8(y.into_inner().to_vec()).unwrap())
                     }
                 }
                 Ok(values)
@@ -246,11 +243,8 @@ impl RedisConnectionPool {
             Ok(RedisValue::Array(val)) => {
                 let mut values = Vec::new();
                 for value in val {
-                    match value {
-                        RedisValue::String(y) => {
-                            values.push(String::from_utf8(y.into_inner().to_vec()).unwrap())
-                        }
-                        _ => (),
+                    if let RedisValue::String(y) = value {
+                        values.push(String::from_utf8(y.into_inner().to_vec()).unwrap())
                     }
                 }
                 Ok(values)
@@ -391,14 +385,11 @@ impl RedisConnectionPool {
                         let mut resp = Vec::new();
                         for point in points {
                             let point = point.as_geo_position().expect("Unable to parse point");
-                            match point {
-                                Some(pos) => {
-                                    resp.push(Point {
-                                        lat: pos.latitude,
-                                        lon: pos.longitude,
-                                    });
-                                }
-                                _ => {}
+                            if let Some(pos) = point {
+                                resp.push(Point {
+                                    lat: pos.latitude,
+                                    lon: pos.longitude,
+                                });
                             }
                         }
                         Ok(resp)
@@ -505,11 +496,8 @@ impl RedisConnectionPool {
             Ok(RedisValue::Array(val)) => {
                 let mut members = Vec::new();
                 for member in val {
-                    match member {
-                        RedisValue::String(y) => {
-                            members.push(String::from_utf8(y.into_inner().to_vec()).unwrap())
-                        }
-                        _ => (),
+                    if let RedisValue::String(y) = member {
+                        members.push(String::from_utf8(y.into_inner().to_vec()).unwrap())
                     }
                 }
                 members.sort();

--- a/crates/shared/src/redis/commands.rs
+++ b/crates/shared/src/redis/commands.rs
@@ -335,6 +335,7 @@ impl RedisConnectionPool {
     }
 
     //GEOSEARCH
+    #[allow(clippy::too_many_arguments)]
     #[instrument(level = "DEBUG", skip(self))]
     pub async fn geo_search(
         &self,
@@ -482,6 +483,7 @@ impl RedisConnectionPool {
     }
 
     //ZRANGE
+    #[allow(clippy::too_many_arguments)]
     pub async fn zrange(
         &self,
         key: &str,

--- a/crates/shared/src/redis/commands.rs
+++ b/crates/shared/src/redis/commands.rs
@@ -370,6 +370,7 @@ impl RedisConnectionPool {
     }
 
     //GEOPOS
+    #[instrument(level = "DEBUG", skip(self))]
     pub async fn geopos(&self, key: &str, members: Vec<String>) -> Result<Vec<Point>, AppError> {
         let output: Result<RedisValue, _> = self
             .pool
@@ -475,6 +476,7 @@ impl RedisConnectionPool {
 
     //ZRANGE
     #[allow(clippy::too_many_arguments)]
+    #[instrument(level = "DEBUG", skip(self))]
     pub async fn zrange(
         &self,
         key: &str,

--- a/crates/shared/src/redis/commands.rs
+++ b/crates/shared/src/redis/commands.rs
@@ -33,8 +33,8 @@ impl RedisConnectionPool {
             .into_report()
             .change_context(AppError::SetFailed);
 
-        if !output.is_ok() {
-            return Err(AppError::SetFailed.into());
+        if output.is_err() {
+            return Err(AppError::SetFailed);
         }
 
         Ok(())
@@ -54,8 +54,8 @@ impl RedisConnectionPool {
             .into_report()
             .change_context(AppError::SetFailed);
 
-        if !output.is_ok() {
-            return Err(AppError::SetFailed.into());
+        if output.is_err() {
+            return Err(AppError::SetFailed);
         }
 
         Ok(())
@@ -85,7 +85,7 @@ impl RedisConnectionPool {
             return Ok(());
         }
 
-        Err(AppError::SetExFailed.into())
+        Err(AppError::SetExFailed)
     }
 
     #[instrument(level = "DEBUG", skip(self))]
@@ -97,8 +97,8 @@ impl RedisConnectionPool {
             .into_report()
             .change_context(AppError::SetExpiryFailed);
 
-        if !output.is_ok() {
-            return Err(AppError::SetExpiryFailed.into());
+        if output.is_err() {
+            return Err(AppError::SetExpiryFailed);
         }
 
         Ok(())
@@ -131,8 +131,8 @@ impl RedisConnectionPool {
             .into_report()
             .change_context(AppError::DeleteFailed);
 
-        if !output.is_ok() {
-            return Err(AppError::DeleteFailed.into());
+        if output.is_err() {
+            return Err(AppError::DeleteFailed);
         }
 
         Ok(())
@@ -157,7 +157,7 @@ impl RedisConnectionPool {
             self.set_expiry(key, self.config.default_hash_ttl.into())
                 .await?;
         } else {
-            return Err(AppError::SetHashFieldFailed.into());
+            return Err(AppError::SetHashFieldFailed);
         }
 
         Ok(())
@@ -176,8 +176,8 @@ impl RedisConnectionPool {
             .into_report()
             .change_context(AppError::GetHashFieldFailed);
 
-        if !output.is_ok() {
-            return Err(AppError::GetHashFieldFailed.into());
+        if output.is_err() {
+            return Err(AppError::GetHashFieldFailed);
         }
 
         Ok(output.unwrap())
@@ -198,9 +198,9 @@ impl RedisConnectionPool {
             .change_context(AppError::RPushFailed);
 
         if let Ok(RedisValue::Integer(length)) = output {
-            return Ok(length);
+            Ok(length)
         } else {
-            return Err(AppError::RPushFailed.into());
+            Err(AppError::RPushFailed)
         }
     }
 
@@ -270,9 +270,9 @@ impl RedisConnectionPool {
             .change_context(AppError::RPushFailed);
 
         if let Ok(RedisValue::Integer(length)) = output {
-            return Ok(length);
+            Ok(length)
         } else {
-            return Err(AppError::RPushFailed.into());
+            Err(AppError::RPushFailed)
         }
     }
 
@@ -295,8 +295,8 @@ impl RedisConnectionPool {
             .into_report()
             .change_context(AppError::GeoAddFailed);
 
-        if !output.is_ok() {
-            return Err(AppError::GeoAddFailed.into());
+        if output.is_err() {
+            return Err(AppError::GeoAddFailed);
         }
 
         Ok(())
@@ -322,8 +322,8 @@ impl RedisConnectionPool {
             .into_report()
             .change_context(AppError::GeoAddFailed);
 
-        if !output.is_ok() {
-            return Err(AppError::GeoAddFailed.into());
+        if output.is_err() {
+            return Err(AppError::GeoAddFailed);
         }
 
         if let Ok(RedisValue::Integer(1)) = output {
@@ -331,7 +331,7 @@ impl RedisConnectionPool {
             return Ok(());
         }
 
-        Err(AppError::SetExFailed.into())
+        Err(AppError::SetExFailed)
     }
 
     //GEOSEARCH
@@ -367,8 +367,8 @@ impl RedisConnectionPool {
             .into_report()
             .change_context(AppError::GeoSearchFailed);
 
-        if !output.is_ok() {
-            return Err(AppError::GeoSearchFailed.into());
+        if output.is_err() {
+            return Err(AppError::GeoSearchFailed);
         }
 
         Ok(output.unwrap())
@@ -400,7 +400,7 @@ impl RedisConnectionPool {
                                 _ => {}
                             }
                         }
-                        return Ok(resp);
+                        Ok(resp)
                     } else if points.len() == 2 && points[0].is_double() && points[1].is_double() {
                         return Ok(vec![Point {
                             lat: points[1].as_f64().expect("Unable to parse lat"),
@@ -410,7 +410,7 @@ impl RedisConnectionPool {
                         return Ok(vec![]);
                     }
                 } else {
-                    return Ok(vec![]);
+                    Ok(vec![])
                 }
             }
             _ => Err(AppError::GeoPosFailed),
@@ -432,8 +432,8 @@ impl RedisConnectionPool {
             .into_report()
             .change_context(AppError::ZremrangeByRankFailed);
 
-        if !output.is_ok() {
-            return Err(AppError::ZremrangeByRankFailed.into());
+        if output.is_err() {
+            return Err(AppError::ZremrangeByRankFailed);
         }
 
         Ok(())
@@ -457,8 +457,8 @@ impl RedisConnectionPool {
             .into_report()
             .change_context(AppError::ZAddFailed);
 
-        if !output.is_ok() {
-            return Err(AppError::ZAddFailed.into());
+        if output.is_err() {
+            return Err(AppError::ZAddFailed);
         }
 
         Ok(())
@@ -474,8 +474,8 @@ impl RedisConnectionPool {
             .into_report()
             .change_context(AppError::ZCardFailed);
 
-        if !output.is_ok() {
-            return Err(AppError::ZCardFailed.into());
+        if output.is_err() {
+            return Err(AppError::ZCardFailed);
         }
 
         Ok(output.unwrap())

--- a/crates/shared/src/tools/error.rs
+++ b/crates/shared/src/tools/error.rs
@@ -87,11 +87,9 @@ pub enum AppError {
 
 impl AppError {
     fn error_message(&self) -> ErrorBody {
-        match self {
-            _ => ErrorBody {
-                message: self.to_string(),
-                code: self.to_string(),
-            },
+        ErrorBody {
+            message: self.to_string(),
+            code: self.to_string(),
         }
     }
 }

--- a/crates/shared/src/utils/logger.rs
+++ b/crates/shared/src/utils/logger.rs
@@ -8,7 +8,7 @@ use tracing_subscriber::{layer::SubscriberExt, EnvFilter, Registry};
 /// Compose multiple layers into a `tracing`'s subscriber.
 pub fn get_subscriber(name: String, env_filter: String) -> impl Subscriber + Send + Sync {
     let env_filter = EnvFilter::try_from_default_env().unwrap_or(EnvFilter::new(env_filter));
-    let formatting_layer = BunyanFormattingLayer::new(name.into(), std::io::stdout);
+    let formatting_layer = BunyanFormattingLayer::new(name, std::io::stdout);
     Registry::default()
         .with(env_filter)
         .with(JsonStorageLayer)


### PR DESCRIPTION
### Description

This PR addresses some `clippy` lints, and allows a few of them. To be precise, this PR includes the following changes (it should be easy to review this PR commit-wise, if required):

- Automatic fixes suggested by clippy (I ran `cargo clippy --all-features --all-targets --fix --allow-dirty` on the workspace).
- Removes the unused `crates/shared/src/mod.rs` file (unused since a `lib.rs` file exists at the top-level).
- Allows the [`clippy::too_many_arguments`](https://rust-lang.github.io/rust-clippy/stable/index.html#/too_many_arguments) and the [`clippy::type_complexity`](https://rust-lang.github.io/rust-clippy/stable/index.html#/type_complexity) lints.
- Replaces single `match` arms with `if let`. This change is an individual commit, and can be reverted if not desired.
- Adds the `instrument` annotation for a couple of Redis command wrappers where it was missing.
- Updates the license identifier in the workspace manifest to `AGPL-3.0-or-later`, based on the license header included in the source code. 

### Motivation and Context

I came across #15 and took the initial steps of addressing lints across the codebase. I can include `just` recipes for running `cargo check` and `cargo clippy` if required, but I'd need help integrating it with the CI workflows (since I don't use nix).