### PR TITLE
lts: reducing success size of lts set api

### DIFF
--- a/crates/location_tracking_service/src/domain/action/ui/location.rs
+++ b/crates/location_tracking_service/src/domain/action/ui/location.rs
@@ -19,7 +19,7 @@ use crate::outbound::external::{
 use crate::redis::{commands::*, keys::*};
 use crate::tools::error::AppError;
 use actix::Arbiter;
-use actix_web::web::Data;
+use actix_web::{web::Data, HttpResponse};
 use chrono::Utc;
 use futures::future::join_all;
 use futures::Future;
@@ -90,7 +90,7 @@ pub async fn update_driver_location(
     data: Data<AppState>,
     mut locations: Vec<UpdateDriverLocationRequest>,
     driver_mode: DriverMode,
-) -> Result<APISuccess, AppError> {
+) -> Result<HttpResponse, AppError> {
     let (driver_id, merchant_id, merchant_operating_city_id) = get_driver_id_from_authentication(
         &data.persistent_redis,
         &data.auth_url,
@@ -129,7 +129,7 @@ pub async fn update_driver_location(
     let latest_driver_location = if let Some(location) = locations.last() {
         location.to_owned()
     } else {
-        return Ok(APISuccess::default());
+        return Ok(HttpResponse::Ok().finish());
     };
 
     info!(
@@ -170,8 +170,7 @@ pub async fn update_driver_location(
         ),
     )
     .await?;
-
-    Ok(APISuccess::default())
+    Ok(HttpResponse::Ok().finish())
 }
 
 #[allow(clippy::type_complexity)]

--- a/crates/location_tracking_service/src/domain/api/ui/location.rs
+++ b/crates/location_tracking_service/src/domain/api/ui/location.rs
@@ -10,7 +10,7 @@ use std::str::FromStr;
 use actix_web::{
     get, post,
     web::{Data, Json, Path},
-    HttpRequest,
+    HttpRequest, HttpResponse,
 };
 
 use crate::{
@@ -26,11 +26,11 @@ pub async fn update_driver_location(
     data: Data<AppState>,
     param_obj: Json<Vec<UpdateDriverLocationRequest>>,
     req: HttpRequest,
-) -> Result<Json<APISuccess>, AppError> {
+) -> Result<HttpResponse, AppError> {
     let request_body = param_obj.into_inner();
 
     if request_body.is_empty() {
-        return Ok(Json(APISuccess::default()));
+        return Ok(HttpResponse::Ok().finish());
     }
 
     let token = req
@@ -60,16 +60,9 @@ pub async fn update_driver_location(
             "dm (DriverMode - Header) not found".to_string(),
         ))?;
 
-    Ok(Json(
-        location::update_driver_location(
-            Token(token),
-            vehicle_type,
-            data,
-            request_body,
-            driver_mode,
-        )
-        .await?,
-    ))
+    location::update_driver_location(Token(token), vehicle_type, data, request_body, driver_mode)
+        .await?;
+    Ok(HttpResponse::Ok().finish())
 }
 
 #[get("/ui/driver/location/{rideId}")]


### PR DESCRIPTION
As we know, this API handles a very high volume of calls, and we work based on the response code of the API, whether it indicates failure or success. Therefore, we should avoid sending unnecessary data, as it will increase the API response size and raise costs at the system level.