### PR TITLE
lts/feat/adding-multiple-vehicle-support-in-nearby-drivers

### DIFF
--- a/crates/location_tracking_service/src/domain/types/internal/location.rs
+++ b/crates/location_tracking_service/src/domain/types/internal/location.rs
@@ -14,7 +14,7 @@ use crate::common::types::*;
 pub struct NearbyDriversRequest {
     pub lat: Latitude,
     pub lon: Longitude,
-    pub vehicle_type: Option<VehicleType>,
+    pub vehicle_type: Option<Vec<VehicleType>>,
     pub radius: Radius,
     pub merchant_id: MerchantId,
 }


### PR DESCRIPTION
For api `/internal/drivers/nearby`
adding the support of receiving multiple vehicle variants in a vector instead of a single variant.
Which results in getting selected vehicle variant drivers only.