### PR TITLE
lts/feat : added ride stop detection check LTS [WIP]

### DIFF
--- a/crates/location_tracking_service/src/common/types.rs
+++ b/crates/location_tracking_service/src/common/types.rs
@@ -203,6 +203,7 @@ pub enum RideInfo {
     Car {
         pickup_location: Point,
         min_distance_between_two_points: Option<i32>,
+        ride_stops: Option<Vec<Point>>,
     },
 }
 
@@ -531,6 +532,7 @@ pub enum DetectionType {
     OppositeDirection,
     TripNotStarted,
     SafetyCheck,
+    RideStopReached,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -541,6 +543,7 @@ pub enum ViolationDetectionState {
     OppositeDirection(OppositeDirectionState),
     TripNotStarted(TripNotStartedState),
     SafetyCheck(SafetyCheckState),
+    RideStopReached(RideStopReachedState),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -580,6 +583,14 @@ pub struct SafetyCheckState {
     pub avg_speed: Option<VecDeque<(f64, u32)>>,
     pub avg_coord_mean: VecDeque<(Point, u32)>,
     pub total_datapoints: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RideStopReachedState {
+    pub total_datapoints: u64,
+    pub reached_stops: Vec<String>,
+    pub current_stop_index: usize,
+    pub avg_coord_mean: VecDeque<(Point, u32)>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -630,6 +641,7 @@ pub enum DetectionConfig {
     OppositeDirectionDetection(OppositeDirectionConfig),
     TripNotStartedDetection(TripNotStartedConfig),
     SafetyCheckDetection(SafetyCheckConfig),
+    RideStopReachedDetection(RideStopReachedConfig),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -638,6 +650,14 @@ pub struct SafetyCheckConfig {
     pub sample_size: u32,
     pub max_eligible_speed: Option<SpeedInMeterPerSecond>,
     pub max_eligible_distance: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RideStopReachedConfig {
+    pub sample_size: u32,
+    pub batch_count: u32,
+    pub stop_reach_threshold: u32,
+    pub min_stop_duration: u32,
 }
 
 #[derive(Debug, Clone)]
@@ -652,6 +672,7 @@ pub struct DetectionContext<'a> {
     pub vehicle_type: VehicleType,
     pub accuracy: Accuracy,
     pub route: Option<&'a Route>,
+    pub ride_stops: Option<&'a Vec<Point>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/location_tracking_service/src/domain/action/ui/location.rs
+++ b/crates/location_tracking_service/src/domain/action/ui/location.rs
@@ -308,6 +308,13 @@ async fn process_driver_locations(
         None
     };
 
+    let ride_stops = driver_ride_info
+        .as_ref()
+        .and_then(|ride_info| match ride_info {
+            RideInfo::Car { ride_stops, .. } => ride_stops.as_ref(),
+            RideInfo::Bus { .. } => None,
+        });
+
     let (
         detection_state,
         anti_detection_state,
@@ -370,6 +377,7 @@ async fn process_driver_locations(
                         vehicle_type: vehicle_type.to_owned(),
                         accuracy: latest_driver_location.acc.unwrap_or(Accuracy(0.0)),
                         route: route.as_ref(),
+                        ride_stops: ride_stops,
                     };
 
                     if let (
@@ -496,6 +504,7 @@ async fn process_driver_locations(
         if let Some(RideInfo::Car {
             pickup_location,
             min_distance_between_two_points: _,
+            ride_stops: _,
         }) = driver_ride_info.as_ref()
         {
             let pickup_distance =
@@ -973,6 +982,7 @@ async fn process_driver_locations(
             Some(RideInfo::Car {
                 pickup_location: _,
                 min_distance_between_two_points: _,
+                ride_stops: _,
             }) => {
                 if let (Some(location), Some(ride_id)) =
                     (stop_detected.as_ref(), driver_ride_id.as_ref())

--- a/crates/location_tracking_service/src/outbound/types.rs
+++ b/crates/location_tracking_service/src/outbound/types.rs
@@ -137,6 +137,7 @@ pub enum DetectionData {
     TripNotStartedDetection(TripNotStartedDetectionData),
     OppositeDirectionDetection(OppositeDirectionDetectionData),
     SafetyCheckDetection(SafetyCheckDetectionData),
+    RideStopReachedDetection(RideStopReachedDetectionData),
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -221,4 +222,14 @@ pub struct OsrmWaypoint {
 #[serde(rename_all = "camelCase")]
 pub struct SafetyCheckDetectionData {
     pub location: Point,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct RideStopReachedDetectionData {
+    pub location: Point,
+    pub stop_name: String,
+    pub stop_code: String,
+    pub stop_index: usize,
+    pub reached_at: TimeStamp,
 }

--- a/dhall-configs/dev/location_tracking_service.dhall
+++ b/dhall-configs/dev/location_tracking_service.dhall
@@ -129,19 +129,27 @@ let safetyCheckDetectionConfig = {
   max_eligible_speed = Some 2,
   max_eligible_distance = 25
 }
+let rideStopReachedDetectionConfig = {
+    sample_size = 10,
+    batch_count = 2,
+    stop_reach_threshold = 100,
+    min_stop_duration = 10,
+}
 let stoppedDetectionConfigT = { max_eligible_distance : Natural, max_eligible_speed : Optional Natural, batch_count : Natural, sample_size : Natural }
 let routeDeviationDetectionConfigT = { deviation_threshold : Natural, sample_size : Natural, batch_count : Natural}
 let overspeedingDetectionConfigT = { sample_size : Natural, speed_limit : Double, batch_count : Natural }
 let oppositeDirectionDetectionConfigT = { sample_size : Natural, batch_count : Natural }
 let tripNotStartedDetectionConfigT = { deviation_threshold : Natural, sample_size : Natural, batch_count : Natural }
 let safetyCheckDetectionConfigT = {max_eligible_distance : Natural, max_eligible_speed : Optional Natural, batch_count : Natural, sample_size : Natural }
+let rideStopReachedDetectionConfigT = { sample_size: Natural, batch_count: Natural , stop_reach_threshold : Natural, min_stop_duration : Natural}
 let DetectionConfigType =
       < StoppedDetection : stoppedDetectionConfigT
       | RouteDeviationDetection : routeDeviationDetectionConfigT
       | OverspeedingDetection : overspeedingDetectionConfigT
       | OppositeDirectionDetection : oppositeDirectionDetectionConfigT
       | TripNotStartedDetection : tripNotStartedDetectionConfigT
-      | SafetyCheckDetection : safetyCheckDetectionConfigT >
+      | SafetyCheckDetection : safetyCheckDetectionConfigT
+      | RideStopReachedDetection : rideStopReachedDetectionConfigT >
 let detection_violation_cab_config_new = {=}
   with Stopped = {
     enabled = False,
@@ -172,6 +180,11 @@ let detection_violation_cab_config_new = {=}
     enabled = False,
     detection_callback_url = "http://127.0.0.1:8016/internal/violationDetection",
     detection_config = DetectionConfigType.SafetyCheckDetection safetyCheckDetectionConfig
+  }
+  with RideStopReached = {
+    enabled = True,
+    detection_callback_url = "http://127.0.0.1:8016/internal/violationDetection",
+    detection_config = DetectionConfigType.RideStopReachedDetection rideStopReachedDetectionConfig
   }
 
 let detection_violation_cab_config_inprogress = {=}
@@ -204,6 +217,11 @@ let detection_violation_cab_config_inprogress = {=}
     enabled = True,
     detection_callback_url = "http://127.0.0.1:8013/internal/violationDetection",
     detection_config = DetectionConfigType.SafetyCheckDetection safetyCheckDetectionConfig
+  }
+  with RideStopReached = {
+    enabled = True,
+    detection_callback_url = "http://127.0.0.1:8016/internal/violationDetection",
+    detection_config = DetectionConfigType.RideStopReachedDetection rideStopReachedDetectionConfig
   }
 
 let detection_violation_bus_config_new = {=}
@@ -291,6 +309,11 @@ let detection_anti_violation_cab_config_new = {=}
     detection_callback_url = "http://127.0.0.1:8016/internal/violationDetection",
     detection_config = DetectionConfigType.SafetyCheckDetection safetyCheckDetectionConfig
   }
+  with RideStopReached = {
+    enabled = True,
+    detection_callback_url = "http://127.0.0.1:8016/internal/violationDetection",
+    detection_config = DetectionConfigType.RideStopReachedDetection rideStopReachedDetectionConfig
+  }
 
 
 let detection_anti_violation_cab_config_inprogress = {=}
@@ -324,6 +347,11 @@ let detection_anti_violation_cab_config_inprogress = {=}
     detection_callback_url = "http://127.0.0.1:8013/internal/violationDetection",
     detection_config = DetectionConfigType.SafetyCheckDetection safetyCheckDetectionConfig
   }
+  with RideStopReached = {
+    enabled = True,
+    detection_callback_url = "http://127.0.0.1:8016/internal/violationDetection",
+    detection_config = DetectionConfigType.RideStopReachedDetection rideStopReachedDetectionConfig
+  }
 
 let detection_anti_violation_bus_config_new = {=}
   with Stopped = {
@@ -351,6 +379,11 @@ let detection_anti_violation_bus_config_new = {=}
     detection_callback_url = "http://127.0.0.1:8016/internal/violationDetection",
     detection_config = DetectionConfigType.TripNotStartedDetection tripNotStartedAntiDetectionConfig
   }
+  with RideStopReached = {
+    enabled = False,
+    detection_callback_url = "http://127.0.0.1:8016/internal/violationDetection",
+    detection_config = DetectionConfigType.RideStopReachedDetection rideStopReachedDetectionConfig
+  }
 
 let detection_anti_violation_bus_config_inprogress = {=}
   with Stopped = {
@@ -377,6 +410,11 @@ let detection_anti_violation_bus_config_inprogress = {=}
     enabled = False,
     detection_callback_url = "http://127.0.0.1:8016/internal/violationDetection",
     detection_config = DetectionConfigType.TripNotStartedDetection tripNotStartedAntiDetectionConfig
+  }
+  with RideStopReached = {
+    enabled = False,
+    detection_callback_url = "http://127.0.0.1:8016/internal/violationDetection",
+    detection_config = DetectionConfigType.RideStopReachedDetection rideStopReachedDetectionConfig
   }
 
 let detection_violation_cab_config = {=}


### PR DESCRIPTION
- added a new violation for reaching stops of a CAR ride 
- added types for handling support 
- created handle_ride_stop_reached_check which handles reaching stop by first calculating the distance between the stop and data points and then checking if the location is within config threshold passing it as a violation
- handled antiviolation by sending isViolated as false