### PR TITLE
backend/feat: group_id in update location

### DIFF
--- a/crates/location_tracking_service/src/common/types.rs
+++ b/crates/location_tracking_service/src/common/types.rs
@@ -303,6 +303,8 @@ pub struct DriverLastKnownLocation {
     pub merchant_id: MerchantId,
     pub bear: Option<Direction>,
     pub vehicle_type: Option<VehicleType>,
+    pub group_id: Option<String>,
+    pub group_id2: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -332,6 +334,7 @@ pub struct DriverAllDetails {
     pub violation_trigger_flag: Option<ViolationDetectionTriggerMap>,
     pub detection_state: Option<ViolationDetectionStateMap>,
     pub anti_detection_state: Option<ViolationDetectionStateMap>,
+    pub group_id: Option<String>,
 }
 
 #[derive(

--- a/crates/location_tracking_service/src/domain/action/internal/ride.rs
+++ b/crates/location_tracking_service/src/domain/action/internal/ride.rs
@@ -163,6 +163,8 @@ pub async fn ride_details(
                 &driver_location.driver_pickup_distance,
                 &driver_location.driver_last_known_location.bear,
                 &driver_location.driver_last_known_location.vehicle_type,
+                &driver_location.driver_last_known_location.group_id,
+                &driver_location.driver_last_known_location.group_id2,
             )
             .await?;
         }
@@ -208,6 +210,8 @@ pub async fn ride_details(
                 &None,
                 &driver_location.driver_last_known_location.bear,
                 &driver_location.driver_last_known_location.vehicle_type,
+                &driver_location.driver_last_known_location.group_id,
+                &driver_location.driver_last_known_location.group_id2,
             )
             .await?;
         }

--- a/crates/location_tracking_service/src/domain/action/ui/location.rs
+++ b/crates/location_tracking_service/src/domain/action/ui/location.rs
@@ -120,12 +120,15 @@ pub async fn update_driver_location(
     data: Data<AppState>,
     mut locations: Vec<UpdateDriverLocationRequest>,
     driver_mode: DriverMode,
+    group_id: Option<String>,
+    group_id2: Option<String>,
+    req_merchant_id: Option<MerchantId>,
 ) -> Result<HttpResponse, AppError> {
     let current_ts = Utc::now();
     let (driver_id, merchant_id, merchant_operating_city_id) = if var("DEV").is_ok() {
         (
             DriverId(token.to_owned().inner()),
-            MerchantId("dev".to_string()),
+            req_merchant_id.unwrap_or_else(|| MerchantId("dev".to_string())),
             MerchantOperatingCityId("dev".to_string()),
         )
     } else {
@@ -217,6 +220,8 @@ pub async fn update_driver_location(
             vehicle_type,
             city,
             driver_mode,
+            group_id,
+            group_id2,
         ),
     )
     .await?;
@@ -238,6 +243,8 @@ async fn process_driver_locations(
         VehicleType,
         CityName,
         DriverMode,
+        Option<String>,
+        Option<String>,
     ),
 ) -> Result<(), AppError> {
     let (
@@ -252,6 +259,8 @@ async fn process_driver_locations(
         vehicle_type,
         city,
         driver_mode,
+        group_id,
+        group_id2,
     ) = args;
 
     let driver_ride_details = get_ride_details(&data.redis, &driver_id, &merchant_id).await?;
@@ -681,6 +690,8 @@ async fn process_driver_locations(
                     &driver_pickup_distance,
                     &None,
                     &Some(vehicle_type.clone()),
+                    &group_id,
+                    &group_id2,
                 )
                 .await?;
                 Ok(())
@@ -832,6 +843,8 @@ async fn process_driver_locations(
                     &driver_pickup_distance,
                     &latest_driver_location.bear,
                     &Some(vehicle_type.clone()),
+                    &group_id,
+                    &group_id2,
                 )
                 .await?;
                 Ok(())

--- a/crates/location_tracking_service/src/domain/api/ui/location.rs
+++ b/crates/location_tracking_service/src/domain/api/ui/location.rs
@@ -60,8 +60,35 @@ pub async fn update_driver_location(
             "dm (DriverMode - Header) not found".to_string(),
         ))?;
 
-    location::update_driver_location(Token(token), vehicle_type, data, request_body, driver_mode)
-        .await?;
+    let group_id = req
+        .headers()
+        .get("gid")
+        .and_then(|header_value| header_value.to_str().ok())
+        .map(|gid_str| gid_str.to_string());
+
+    let group_id2 = req
+        .headers()
+        .get("gid2")
+        .and_then(|header_value| header_value.to_str().ok())
+        .map(|gid_str| gid_str.to_string());
+
+    let req_merchant_id = req
+        .headers()
+        .get("mid")
+        .and_then(|header_value| header_value.to_str().ok())
+        .map(|mid_str| MerchantId(mid_str.to_string()));
+
+    location::update_driver_location(
+        Token(token),
+        vehicle_type,
+        data,
+        request_body,
+        driver_mode,
+        group_id,
+        group_id2,
+        req_merchant_id,
+    )
+    .await?;
     Ok(HttpResponse::Ok().finish())
 }
 

--- a/crates/location_tracking_service/src/domain/types/internal/location.rs
+++ b/crates/location_tracking_service/src/domain/types/internal/location.rs
@@ -18,6 +18,7 @@ pub struct NearbyDriversRequest {
     pub radius: Radius,
     pub merchant_id: MerchantId,
     pub group_id: Option<String>,
+    pub group_id2: Option<String>,
 }
 
 pub type NearbyDriverResponse = Vec<DriverLocationDetail>;
@@ -48,6 +49,8 @@ pub struct DriverLocationDetail {
     pub created_at: TimeStamp,
     pub updated_at: TimeStamp,
     pub merchant_id: MerchantId,
+    pub group_id: Option<String>,
+    pub group_id2: Option<String>,
     pub bear: Option<Direction>,
     pub ride_details: Option<RideDetailsApiEntity>,
     pub vehicle_type: Option<VehicleType>,

--- a/crates/location_tracking_service/src/redis/commands.rs
+++ b/crates/location_tracking_service/src/redis/commands.rs
@@ -333,6 +333,8 @@ pub async fn set_driver_last_location_update(
     driver_pickup_distance: &Option<Meters>,
     bear: &Option<Direction>,
     vehicle_type: &Option<VehicleType>,
+    group_id: &Option<String>,
+    group_id2: &Option<String>,
 ) -> Result<DriverLastKnownLocation, AppError> {
     let last_known_location = DriverLastKnownLocation {
         location: Point {
@@ -343,6 +345,8 @@ pub async fn set_driver_last_location_update(
         merchant_id: merchant_id.to_owned(),
         bear: *bear,
         vehicle_type: *vehicle_type,
+        group_id: group_id.clone(),
+        group_id2: group_id2.clone(),
     };
 
     let value = DriverAllDetails {
@@ -355,6 +359,7 @@ pub async fn set_driver_last_location_update(
         detection_state: detection_state.to_owned(),
         violation_trigger_flag: violation_trigger_flag.clone(),
         anti_detection_state: anti_detection_state.clone(),
+        group_id: group_id.clone(),
     };
 
     redis


### PR DESCRIPTION
add `group_id` in this api:

`POST /ui/driver/location`

Currently we use `group_id` only here for BUS case:
```

POST /internal/ride/{rideId}/create
POST /internal/ride/{rideId}/start
POST /internal/ride/{rideId}/end
POST /internal/ride/rideDetails
```