### PR TITLE
feat: add API to retrieve queue drivers for special locations

### DIFF
--- a/crates/location_tracking_service/src/domain/action/internal/location.rs
+++ b/crates/location_tracking_service/src/domain/action/internal/location.rs
@@ -676,6 +676,32 @@ pub async fn manual_queue_add(
     Ok(APISuccess::default())
 }
 
+pub async fn get_queue_drivers(
+    data: Data<AppState>,
+    special_location_id: String,
+    vehicle_type: String,
+) -> Result<QueueDriversResponse, AppError> {
+    let scores =
+        get_queue_scores_at_range(&data.redis, &special_location_id, &vehicle_type, 0, -1).await?;
+    let drivers = scores
+        .into_iter()
+        .enumerate()
+        .filter_map(|(idx, (member, _score))| {
+            serde_json::from_str::<String>(&member)
+                .ok()
+                .map(|id| QueueDriverEntry {
+                    driver_id: DriverId(id),
+                    queue_position: (idx as u64) + 1,
+                })
+        })
+        .collect::<Vec<_>>();
+    let queue_size = drivers.len() as u64;
+    Ok(QueueDriversResponse {
+        drivers,
+        queue_size,
+    })
+}
+
 pub async fn get_special_location_drivers(
     data: Data<AppState>,
     special_location_id: String,

--- a/crates/location_tracking_service/src/domain/api/internal/location.rs
+++ b/crates/location_tracking_service/src/domain/api/internal/location.rs
@@ -96,6 +96,17 @@ async fn get_driver_queue_position(
     ))
 }
 
+#[get("/internal/special-locations/{special_location_id}/queue/{vehicle_type}/drivers")]
+async fn get_queue_drivers(
+    data: Data<AppState>,
+    path: Path<(String, String)>,
+) -> Result<Json<QueueDriversResponse>, AppError> {
+    let (special_location_id, vehicle_type) = path.into_inner();
+    Ok(Json(
+        location::get_queue_drivers(data, special_location_id, vehicle_type).await?,
+    ))
+}
+
 #[delete("/internal/special-locations/{special_location_id}/queue/{vehicle_type}/drivers/{merchant_id}/{driver_id}")]
 async fn manual_queue_remove(
     data: Data<AppState>,

--- a/crates/location_tracking_service/src/domain/api/mod.rs
+++ b/crates/location_tracking_service/src/domain/api/mod.rs
@@ -27,6 +27,7 @@ pub fn handler(config: &mut ServiceConfig) {
         .service(internal::location::post_track_vehicles)
         .service(internal::location::get_special_location_drivers)
         .service(internal::location::get_driver_queue_position)
+        .service(internal::location::get_queue_drivers)
         .service(internal::location::manual_queue_remove)
         .service(internal::location::manual_queue_add)
         .service(external::gps::external_gps_location)

--- a/crates/location_tracking_service/src/domain/types/internal/location.rs
+++ b/crates/location_tracking_service/src/domain/types/internal/location.rs
@@ -101,3 +101,19 @@ pub struct DriverQueuePositionResponse {
 pub struct ManualQueueAddRequest {
     pub queue_position: u64, // 1-indexed desired position
 }
+
+/// A single driver entry in the queue
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct QueueDriverEntry {
+    pub driver_id: DriverId,
+    pub queue_position: u64, // 1-indexed
+}
+
+/// Response for GET /internal/special-locations/{special_location_id}/queue/{vehicle_type}/drivers
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct QueueDriversResponse {
+    pub drivers: Vec<QueueDriverEntry>,
+    pub queue_size: u64,
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an internal API endpoint to retrieve all drivers currently queued for a specific location and vehicle type, with each driver's queue position included in the response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->