### PR TITLE
feat: add debug logs and cache inspection for special location queuing

### DIFF
--- a/crates/location_tracking_service/src/domain/api/internal/location.rs
+++ b/crates/location_tracking_service/src/domain/api/internal/location.rs
@@ -74,6 +74,36 @@ async fn post_track_vehicles(
     Ok(Json(location::track_vehicles(data, request_body).await?))
 }
 
+#[get("/internal/special-locations/cached")]
+async fn get_cached_special_locations(
+    data: Data<AppState>,
+) -> Result<Json<CachedSpecialLocationsResponse>, AppError> {
+    let guard = data.special_location_cache.read().await;
+    let mut total_count = 0usize;
+    let cities = guard
+        .iter()
+        .map(|(city_id, entries)| {
+            total_count += entries.len();
+            CachedSpecialLocationCityGroup {
+                merchant_operating_city_id: city_id.0.clone(),
+                count: entries.len(),
+                special_locations: entries
+                    .iter()
+                    .map(|e| CachedSpecialLocationEntry {
+                        id: e.id.0.clone(),
+                        is_queue_enabled: e.is_queue_enabled,
+                        is_open_market_enabled: e.is_open_market_enabled,
+                    })
+                    .collect(),
+            }
+        })
+        .collect();
+    Ok(Json(CachedSpecialLocationsResponse {
+        total_count,
+        cities,
+    }))
+}
+
 #[get("/internal/special-locations/{special_location_id}/drivers")]
 async fn get_special_location_drivers(
     data: Data<AppState>,

--- a/crates/location_tracking_service/src/domain/api/mod.rs
+++ b/crates/location_tracking_service/src/domain/api/mod.rs
@@ -25,6 +25,7 @@ pub fn handler(config: &mut ServiceConfig) {
         .service(internal::location::driver_block_till)
         .service(internal::location::track_vehicles)
         .service(internal::location::post_track_vehicles)
+        .service(internal::location::get_cached_special_locations)
         .service(internal::location::get_special_location_drivers)
         .service(internal::location::get_driver_queue_position)
         .service(internal::location::get_queue_drivers)

--- a/crates/location_tracking_service/src/domain/types/internal/location.rs
+++ b/crates/location_tracking_service/src/domain/types/internal/location.rs
@@ -78,6 +78,32 @@ pub struct TrackVehicleResponse {
     pub vehicle_info: VehicleTrackingInfo,
 }
 
+/// A single cached special location entry (debug).
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct CachedSpecialLocationEntry {
+    pub id: String,
+    pub is_queue_enabled: bool,
+    pub is_open_market_enabled: bool,
+}
+
+/// Group of cached special locations per city (debug).
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct CachedSpecialLocationCityGroup {
+    pub merchant_operating_city_id: String,
+    pub count: usize,
+    pub special_locations: Vec<CachedSpecialLocationEntry>,
+}
+
+/// Response for GET /internal/special-locations/cached
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct CachedSpecialLocationsResponse {
+    pub total_count: usize,
+    pub cities: Vec<CachedSpecialLocationCityGroup>,
+}
+
 /// Response for GET /internal/special-locations/{special_location_id}/drivers
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]

--- a/crates/location_tracking_service/src/drainer.rs
+++ b/crates/location_tracking_service/src/drainer.rs
@@ -118,8 +118,10 @@ async fn drain_queue_actions(
                 timestamp,
             } => {
                 if *is_on_ride {
+                    info!(tag = "[Queue Skip On Ride]", driver_id = %driver_id, special_location_id = %special_location_id, "Driver is on ride, skipping queue entry");
                     continue;
                 }
+                info!(tag = "[Queue Enter Processing]", driver_id = %driver_id, special_location_id = %special_location_id, vehicle_type = %vehicle_type, "Processing queue enter, old_tracking={:?}", old_tracking);
                 let new_tracking = DriverQueueTracking {
                     special_location_id: special_location_id.clone(),
                     vehicle_type: vehicle_type.clone(),
@@ -168,6 +170,7 @@ async fn drain_queue_actions(
                 merchant_id,
                 driver_id,
             } => {
+                info!(tag = "[Queue Exit Processing]", driver_id = %driver_id, has_tracking = %old_tracking.is_some(), "Processing possible exit");
                 if let Some(ref tracking) = old_tracking {
                     // ZREM from queue
                     let queue_key = special_location_queue_key(
@@ -363,12 +366,15 @@ pub async fn run_drainer(
 
                         let skip_normal_drain = if let Some(ref cache) = special_location_cache {
                             let guard = cache.read().await;
+                            let city_entry_count = guard.get(&merchant_operating_city_id).map(|v| v.len()).unwrap_or(0);
+                            info!(tag = "[Special Location Lookup]", driver_id = %driver_id, city_id = %merchant_operating_city_id.0, lat = %latitude, lon = %longitude, "Cache has {} locations for this city", city_entry_count);
                             if let Some(entry) = lookup_special_location(
                                 &guard,
                                 &merchant_operating_city_id,
                                 &Latitude(latitude),
                                 &Longitude(longitude),
                             ) {
+                                info!(tag = "[Special Location Match]", driver_id = %driver_id, special_location_id = %entry.id.0, queue_enabled = %entry.is_queue_enabled, open_market = %entry.is_open_market_enabled);
                                 if enable_special_location_bucketing {
                                     special_location_zset_entries
                                         .entry(entry.id.0.clone())
@@ -381,6 +387,7 @@ pub async fn run_drainer(
                                 }
                                 // Queue entry: if this special location is queue-enabled, enqueue driver
                                 if entry.is_queue_enabled {
+                                    info!(tag = "[Queue Action]", driver_id = %driver_id, special_location_id = %entry.id.0, vehicle_type = %vehicle_type, "Pushing Enter action");
                                     queue_actions.push(QueueAction::Enter {
                                         merchant_id: merchant_id.0.clone(),
                                         driver_id: driver_id.clone(),
@@ -392,6 +399,7 @@ pub async fn run_drainer(
                                 !entry.is_open_market_enabled
                             } else {
                                 // No special location match → possible exit from queue
+                                info!(tag = "[Special Location No Match]", driver_id = %driver_id, city_id = %merchant_operating_city_id.0, lat = %latitude, lon = %longitude, "No geofence match, pushing PossibleExit");
                                 queue_actions.push(QueueAction::PossibleExit {
                                     merchant_id: merchant_id.0.clone(),
                                     driver_id: driver_id.clone(),
@@ -399,6 +407,7 @@ pub async fn run_drainer(
                                 false
                             }
                         } else {
+                            info!(tag = "[Special Location Cache]", driver_id = %driver_id, "Cache is None (special_location_list_base_url not set)");
                             false
                         };
 

--- a/crates/location_tracking_service/src/main.rs
+++ b/crates/location_tracking_service/src/main.rs
@@ -18,7 +18,6 @@ use location_tracking_service::{
     tools::{error::AppError, prometheus::prometheus_metrics},
 };
 use shared::{middleware::incoming_request::IncomingRequestMetrics, tools::logger::setup_tracing};
-use tracing::info;
 use shared::{termination, tools::prometheus::TERMINATION};
 use std::{
     env::var,
@@ -32,6 +31,7 @@ use tokio::{
     sync::mpsc::{self, Receiver, Sender},
 };
 use tracing::error;
+use tracing::info;
 use tracing_actix_web::TracingLogger;
 
 #[actix_web::main]
@@ -150,20 +150,39 @@ async fn start_server() -> std::io::Result<()> {
         tokio::spawn(async move {
             match get_special_locations_list(&base_url).await {
                 Ok(list) => {
-                    info!(tag = "[Special Location Cache]", "Fetched {} special locations from API", list.len());
+                    info!(
+                        tag = "[Special Location Cache]",
+                        "Fetched {} special locations from API",
+                        list.len()
+                    );
                     let new_map = build_special_location_cache(list);
                     let total_entries: usize = new_map.values().map(|v| v.len()).sum();
-                    info!(tag = "[Special Location Cache]", "Built cache with {} cities, {} locations (after filtering)", new_map.len(), total_entries);
+                    info!(
+                        tag = "[Special Location Cache]",
+                        "Built cache with {} cities, {} locations (after filtering)",
+                        new_map.len(),
+                        total_entries
+                    );
                     for (city_id, entries) in &new_map {
                         for entry in entries {
-                            info!(tag = "[Special Location Cache]", "  city={} id={} queue_enabled={} open_market={}", city_id.0, entry.id.0, entry.is_queue_enabled, entry.is_open_market_enabled);
+                            info!(
+                                tag = "[Special Location Cache]",
+                                "  city={} id={} queue_enabled={} open_market={}",
+                                city_id.0,
+                                entry.id.0,
+                                entry.is_queue_enabled,
+                                entry.is_open_market_enabled
+                            );
                         }
                     }
                     let mut guard = cache.write().await;
                     *guard = new_map;
                 }
                 Err(e) => {
-                    error!(tag = "[Special Location Cache]", "Failed to fetch special locations: {}", e);
+                    error!(
+                        tag = "[Special Location Cache]",
+                        "Failed to fetch special locations: {}", e
+                    );
                 }
             }
             let mut interval = tokio::time::interval(Duration::from_secs(300));
@@ -171,15 +190,27 @@ async fn start_server() -> std::io::Result<()> {
                 interval.tick().await;
                 match get_special_locations_list(&base_url).await {
                     Ok(list) => {
-                        info!(tag = "[Special Location Cache Refresh]", "Fetched {} special locations", list.len());
+                        info!(
+                            tag = "[Special Location Cache Refresh]",
+                            "Fetched {} special locations",
+                            list.len()
+                        );
                         let new_map = build_special_location_cache(list);
                         let total_entries: usize = new_map.values().map(|v| v.len()).sum();
-                        info!(tag = "[Special Location Cache Refresh]", "Rebuilt cache with {} cities, {} locations", new_map.len(), total_entries);
+                        info!(
+                            tag = "[Special Location Cache Refresh]",
+                            "Rebuilt cache with {} cities, {} locations",
+                            new_map.len(),
+                            total_entries
+                        );
                         let mut guard = cache.write().await;
                         *guard = new_map;
                     }
                     Err(e) => {
-                        error!(tag = "[Special Location Cache Refresh]", "Failed to refresh: {}", e);
+                        error!(
+                            tag = "[Special Location Cache Refresh]",
+                            "Failed to refresh: {}", e
+                        );
                     }
                 }
             }

--- a/crates/location_tracking_service/src/main.rs
+++ b/crates/location_tracking_service/src/main.rs
@@ -18,6 +18,7 @@ use location_tracking_service::{
     tools::{error::AppError, prometheus::prometheus_metrics},
 };
 use shared::{middleware::incoming_request::IncomingRequestMetrics, tools::logger::setup_tracing};
+use tracing::info;
 use shared::{termination, tools::prometheus::TERMINATION};
 use std::{
     env::var,
@@ -147,18 +148,39 @@ async fn start_server() -> std::io::Result<()> {
         let cache = data.special_location_cache.clone();
         let base_url = base_url.clone();
         tokio::spawn(async move {
-            if let Ok(list) = get_special_locations_list(&base_url).await {
-                let new_map = build_special_location_cache(list);
-                let mut guard = cache.write().await;
-                *guard = new_map;
+            match get_special_locations_list(&base_url).await {
+                Ok(list) => {
+                    info!(tag = "[Special Location Cache]", "Fetched {} special locations from API", list.len());
+                    let new_map = build_special_location_cache(list);
+                    let total_entries: usize = new_map.values().map(|v| v.len()).sum();
+                    info!(tag = "[Special Location Cache]", "Built cache with {} cities, {} locations (after filtering)", new_map.len(), total_entries);
+                    for (city_id, entries) in &new_map {
+                        for entry in entries {
+                            info!(tag = "[Special Location Cache]", "  city={} id={} queue_enabled={} open_market={}", city_id.0, entry.id.0, entry.is_queue_enabled, entry.is_open_market_enabled);
+                        }
+                    }
+                    let mut guard = cache.write().await;
+                    *guard = new_map;
+                }
+                Err(e) => {
+                    error!(tag = "[Special Location Cache]", "Failed to fetch special locations: {}", e);
+                }
             }
             let mut interval = tokio::time::interval(Duration::from_secs(300));
             loop {
                 interval.tick().await;
-                if let Ok(list) = get_special_locations_list(&base_url).await {
-                    let new_map = build_special_location_cache(list);
-                    let mut guard = cache.write().await;
-                    *guard = new_map;
+                match get_special_locations_list(&base_url).await {
+                    Ok(list) => {
+                        info!(tag = "[Special Location Cache Refresh]", "Fetched {} special locations", list.len());
+                        let new_map = build_special_location_cache(list);
+                        let total_entries: usize = new_map.values().map(|v| v.len()).sum();
+                        info!(tag = "[Special Location Cache Refresh]", "Rebuilt cache with {} cities, {} locations", new_map.len(), total_entries);
+                        let mut guard = cache.write().await;
+                        *guard = new_map;
+                    }
+                    Err(e) => {
+                        error!(tag = "[Special Location Cache Refresh]", "Failed to refresh: {}", e);
+                    }
                 }
             }
         });


### PR DESCRIPTION
## Summary
- Add detailed logging in drainer for special location geofence lookup, queue entry/exit decisions, and on-ride skip reasons
- Add startup and periodic refresh logs for special location cache showing per-city, per-location details (id, flags)
- Add `GET /internal/special-locations/cached` endpoint to inspect the in-memory special location cache from within the pod (`curl localhost:<port>/internal/special-locations/cached`)

## Test plan
- [ ] Deploy to staging and verify logs appear on driver location pings near special locations
- [ ] Exec into pod and curl `/internal/special-locations/cached` to verify cache is populated
- [ ] Confirm logs show correct geofence match/miss and queue entry/skip reasons

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an internal API endpoint for retrieving cached special locations data.

* **Chores**
  * Enhanced observability with additional logging for location tracking operations and error handling in cache refresh cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->