### PR TITLE
fix: special location cache deserialization and error logging

### DIFF
--- a/crates/location_tracking_service/src/main.rs
+++ b/crates/location_tracking_service/src/main.rs
@@ -181,7 +181,9 @@ async fn start_server() -> std::io::Result<()> {
                 Err(e) => {
                     error!(
                         tag = "[Special Location Cache]",
-                        "Failed to fetch special locations: {}", e
+                        "Failed to fetch special locations: {} - {}",
+                        e,
+                        e.message()
                     );
                 }
             }
@@ -209,7 +211,9 @@ async fn start_server() -> std::io::Result<()> {
                     Err(e) => {
                         error!(
                             tag = "[Special Location Cache Refresh]",
-                            "Failed to refresh: {}", e
+                            "Failed to refresh: {} - {}",
+                            e,
+                            e.message()
                         );
                     }
                 }

--- a/crates/location_tracking_service/src/outbound/types.rs
+++ b/crates/location_tracking_service/src/outbound/types.rs
@@ -18,6 +18,7 @@ pub struct SpecialLocationFull {
     pub id: SpecialLocationId,
     pub merchant_operating_city_id: Option<String>,
     pub geo_json: Option<String>,
+    #[serde(default)]
     pub is_open_market_enabled: bool,
     #[serde(default)]
     pub is_queue_enabled: bool,


### PR DESCRIPTION
## Summary
- Add `#[serde(default)]` to `is_open_market_enabled` in `SpecialLocationFull` — if any location in the API response has this field missing or null, the entire array deserialization was failing silently
- Improve error logs in special location cache fetch to show actual error message (`e.message()`) instead of just the error code (`INTERNAL_ERROR`)

## Test plan
- [ ] Deploy and verify `/internal/special-locations/cached` returns populated cache
- [ ] Check logs show actual deserialization error details if any remain