### PR TITLE
fix: handle null booleans in special location API and deserialize per-entry

### DIFF
--- a/crates/location_tracking_service/src/outbound/external.rs
+++ b/crates/location_tracking_service/src/outbound/external.rs
@@ -513,6 +513,7 @@ pub async fn refresh_external_trace_token(
 
 /// Fetches special locations list from internal driver app.
 /// Uses getAllLocations=true so one call returns data for all cities (JSON response).
+/// Deserializes each entry individually so one bad entry doesn't break the entire list.
 pub async fn get_special_locations_list(
     base_url: &Url,
 ) -> Result<Vec<SpecialLocationFull>, AppError> {
@@ -522,7 +523,7 @@ pub async fn get_special_locations_list(
         base_str
     );
     let url = Url::parse(&url).map_err(|e| AppError::InvalidRequest(e.to_string()))?;
-    call_api::<Vec<SpecialLocationFull>, ()>(
+    let raw: Vec<serde_json::Value> = call_api::<Vec<serde_json::Value>, ()>(
         Protocol::Http1,
         Method::GET,
         &url,
@@ -531,5 +532,23 @@ pub async fn get_special_locations_list(
         Some("special-location-list"),
     )
     .await
-    .map_err(|e| AppError::InternalError(e.to_string()))
+    .map_err(|e| AppError::InternalError(e.to_string()))?;
+
+    let total = raw.len();
+    let mut results = Vec::with_capacity(total);
+    for (i, item) in raw.into_iter().enumerate() {
+        match serde_json::from_value::<SpecialLocationFull>(item) {
+            Ok(loc) => results.push(loc),
+            Err(e) => {
+                tracing::warn!(
+                    tag = "[Special Location Deserialize]",
+                    "Skipping entry {}/{}: {}",
+                    i,
+                    total,
+                    e
+                );
+            }
+        }
+    }
+    Ok(results)
 }

--- a/crates/location_tracking_service/src/outbound/types.rs
+++ b/crates/location_tracking_service/src/outbound/types.rs
@@ -6,10 +6,18 @@
     the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::common::types::*;
 use std::collections::HashMap;
+
+/// Deserialize a bool that may be null or missing — treats both as false.
+fn bool_or_false<'de, D>(deserializer: D) -> Result<bool, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Ok(Option::<bool>::deserialize(deserializer)?.unwrap_or(false))
+}
 
 // Special location API response (only fields we use; API returns camelCase JSON)
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -18,9 +26,9 @@ pub struct SpecialLocationFull {
     pub id: SpecialLocationId,
     pub merchant_operating_city_id: Option<String>,
     pub geo_json: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "bool_or_false")]
     pub is_open_market_enabled: bool,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "bool_or_false")]
     pub is_queue_enabled: bool,
 }
 


### PR DESCRIPTION
## Summary
- The API returns `"isQueueEnabled": null` for some locations. `#[serde(default)]` only handles **missing** fields, not `null` — this was causing `DESERIALIZATION_ERROR` and the entire cache staying empty.
- Added `bool_or_false` custom deserializer that handles both missing and `null` → `false`
- Changed `get_special_locations_list` to deserialize each entry individually (fetch as `Vec<Value>`, then parse each). One bad entry no longer kills the entire list — it gets skipped with a warning log.

## Test plan
- [ ] Deploy and verify `/internal/special-locations/cached` returns populated cache
- [ ] Check logs for `[Special Location Deserialize] Skipping entry` to see if any entries still fail

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Location list retrieval now skips and logs malformed entries instead of failing the whole request.
  * Null/missing location configuration flags consistently default to disabled.

* **Refactor**
  * Special-location processing streamlined and made non-blocking when cache is busy, with clearer fallback behavior so normal processing continues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->