### PR TITLE
feat: consume fleetOperator location in rider endpoints with auth; fo…

### DIFF
--- a/crates/location_tracking_service/src/domain/action/ui/location.rs
+++ b/crates/location_tracking_service/src/domain/action/ui/location.rs
@@ -277,6 +277,97 @@ pub async fn update_driver_location_by_token(
     Ok(HttpResponse::Ok().finish())
 }
 
+/// Handle fleet operator location updates by forwarding to gtfs-specific Kafka topic
+async fn handle_fleet_operator_location(
+    data: Data<AppState>,
+    locations: Vec<UpdatePersonLocationRequest>,
+    gtfs_id: String,
+    vehicle_number: String,
+    token: Token,
+) -> Result<HttpResponse, AppError> {
+    // Look up the Kafka topic for this gtfs_id
+    let kafka_topic = data
+        .fleet_operator_kafka_topics
+        .get(&gtfs_id)
+        .cloned()
+        .ok_or_else(|| {
+            AppError::InvalidRequest(format!(
+                "No Kafka topic configured for gtfs_id: {}",
+                gtfs_id
+            ))
+        })?;
+
+    // Authenticate the token using rider auth (fleet operators use riderOtpAuth)
+    let (person_id, _merchant_id, _merchant_operating_city_id) = get_rider_id_from_authentication(
+        &data.redis,
+        &data.rider_auth_url,
+        &data.rider_auth_api_key,
+        &data.rider_auth_token_expiry,
+        &token,
+    )
+    .await?;
+
+    info!(
+        "Processing fleet operator location for person_id: {:?}, vehicle: {}, gtfs_id: {}, topic: {}",
+        person_id, vehicle_number, gtfs_id, kafka_topic
+    );
+
+    // Produce each location to the Kafka topic
+    if let Some(ref producer) = data.producer {
+        for location in locations {
+            let message = serde_json::json!({
+                "lat": location.pt.lat.inner(),
+                "long": location.pt.lon.inner(),
+                "timestamp": location.ts.inner().timestamp(),
+                "accuracy": location.acc.map(|a| a.inner()),
+                "speed": location.v.map(|s| s.inner()),
+                "bearing": location.bear.map(|b| b.inner()),
+                "vehicleNumber": vehicle_number,
+                "gtfsId": gtfs_id,
+                "operatorType": "fleetOperator",
+                "deviceId": format!("fleet_{}", vehicle_number),
+                "pushedToKafkaAt": Utc::now().timestamp(),
+                "serverTime": Utc::now().timestamp(),
+                "provider": "fleet-operator",
+            });
+
+            let payload = match serde_json::to_string(&message) {
+                Ok(json) => json,
+                Err(e) => {
+                    warn!("Failed to serialize fleet operator location: {}", e);
+                    continue;
+                }
+            };
+
+            let record = rdkafka::producer::FutureRecord::to(&kafka_topic)
+                .payload(&payload)
+                .key(&vehicle_number);
+
+            match producer
+                .send(record, std::time::Duration::from_secs(5))
+                .await
+            {
+                Ok((partition, offset)) => {
+                    debug!(
+                        "Sent fleet operator location to {} partition {} offset {}",
+                        kafka_topic, partition, offset
+                    );
+                }
+                Err((e, _)) => {
+                    warn!(
+                        "Failed to send fleet operator location to Kafka topic {}: {}",
+                        kafka_topic, e
+                    );
+                }
+            }
+        }
+    } else {
+        warn!("Kafka producer not available for fleet operator location");
+    }
+
+    Ok(HttpResponse::Ok().finish())
+}
+
 /// Simplified version for external GPS providers that already have driver_id
 /// No token authentication needed
 #[macros::measure_duration]
@@ -1353,17 +1444,31 @@ pub async fn track_person_entity_location(
     })
 }
 
-/// Generic: update person location (batch). Rider-only for now; uses generic keys and entity_loc vector.
+/// Generic: update person location (batch). Supports Rider, Driver (delegated), and FleetOperator.
+/// For FleetOperator, gtfs_id and vehicle_number must be provided.
 pub async fn update_person_location(
     person_type: PersonType,
     token: Token,
     data: Data<AppState>,
     locations: Vec<UpdatePersonLocationRequest>,
+    gtfs_id: Option<String>,
+    vehicle_number: Option<String>,
 ) -> Result<HttpResponse, AppError> {
     if locations.is_empty() {
         return Ok(HttpResponse::Ok().finish());
     }
     match person_type {
+        PersonType::FleetOperator => {
+            // Fleet operator: forward to Kafka topic
+            if let (Some(gtfs_id), Some(vehicle_number)) = (gtfs_id, vehicle_number) {
+                handle_fleet_operator_location(data, locations, gtfs_id, vehicle_number, token)
+                    .await
+            } else {
+                Err(AppError::InvalidRequest(
+                    "Fleet operator requires gtfs_id and vehicle_number headers".to_string(),
+                ))
+            }
+        }
         PersonType::Rider => {
             let (person_id, merchant_id, _merchant_operating_city_id) =
                 get_rider_id_from_authentication(

--- a/crates/location_tracking_service/src/domain/api/ui/location.rs
+++ b/crates/location_tracking_service/src/domain/api/ui/location.rs
@@ -117,6 +117,7 @@ pub async fn track_person_entity_location(
 }
 
 /// Generic: update person location (batch). Path: person_type. Body: Vec<UpdatePersonLocationRequest>.
+/// Optional headers for fleet operator: gtfsId, vehicleNumber
 #[post("/ui/location/{person_type}")]
 pub async fn update_person_location(
     data: Data<AppState>,
@@ -136,5 +137,27 @@ pub async fn update_person_location(
         .ok_or(AppError::InvalidRequest(
             "token (Header) not found".to_string(),
         ))?;
-    location::update_person_location(person_type, Token(token), data, request_body).await
+
+    // Extract optional fleet operator headers
+    let gtfs_id = req
+        .headers()
+        .get("gtfsId")
+        .and_then(|h| h.to_str().ok())
+        .map(String::from);
+
+    let vehicle_number = req
+        .headers()
+        .get("vehicleNumber")
+        .and_then(|h| h.to_str().ok())
+        .map(String::from);
+
+    location::update_person_location(
+        person_type,
+        Token(token),
+        data,
+        request_body,
+        gtfs_id,
+        vehicle_number,
+    )
+    .await
 }

--- a/crates/location_tracking_service/src/domain/types/ui/location.rs
+++ b/crates/location_tracking_service/src/domain/types/ui/location.rs
@@ -9,12 +9,13 @@ use crate::common::types::*;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
-/// Person type for generic location APIs (rider or driver).
+/// Person type for generic location APIs (rider, driver, or fleet operator).
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum PersonType {
     Rider,
     Driver,
+    FleetOperator,
 }
 
 impl FromStr for PersonType {
@@ -24,6 +25,7 @@ impl FromStr for PersonType {
         match s.to_lowercase().as_str() {
             "rider" => Ok(PersonType::Rider),
             "driver" => Ok(PersonType::Driver),
+            "fleetoperator" | "fleet_operator" => Ok(PersonType::FleetOperator),
             _ => Err(()),
         }
     }
@@ -34,6 +36,7 @@ impl PersonType {
         match self {
             PersonType::Rider => "rider",
             PersonType::Driver => "driver",
+            PersonType::FleetOperator => "fleetOperator",
         }
     }
 }

--- a/crates/location_tracking_service/src/environment.rs
+++ b/crates/location_tracking_service/src/environment.rs
@@ -87,6 +87,9 @@ pub struct AppConfig {
     pub special_location_list_base_url: Option<String>,
     #[serde(default)]
     pub enable_special_location_bucketing: bool,
+    /// Mapping of gtfs_id to Kafka topic for fleet operator location updates
+    #[serde(default)]
+    pub fleet_operator_kafka_topics: HashMap<String, String>,
     #[serde(default = "default_queue_expiry")]
     pub queue_expiry_seconds: u64,
     #[serde(default = "default_queue_position_range_offset")]
@@ -245,6 +248,8 @@ pub struct AppState {
     pub queue_exit_hysteresis_threshold: u32,
     pub enable_queue_cache_empty_guard: bool,
     pub special_location_entry_ts_ttl_sec: u64,
+    /// Mapping of gtfs_id to Kafka topic for fleet operator location updates
+    pub fleet_operator_kafka_topics: HashMap<String, String>,
 }
 
 impl AppState {
@@ -462,6 +467,7 @@ impl AppState {
             queue_exit_hysteresis_threshold: app_config.queue_exit_hysteresis_threshold,
             enable_queue_cache_empty_guard: app_config.enable_queue_cache_empty_guard,
             special_location_entry_ts_ttl_sec: app_config.special_location_entry_ts_ttl_sec,
+            fleet_operator_kafka_topics: app_config.fleet_operator_kafka_topics,
         }
     }
 }

--- a/dhall-configs/dev/location_tracking_service.dhall
+++ b/dhall-configs/dev/location_tracking_service.dhall
@@ -450,6 +450,10 @@ let detection_anti_violation_config = {=}
   with BUS_AC = detection_anti_violation_bus_config
   with AUTO_RICKSHAW = detection_anti_violation_cab_config
   with BIKE = detection_anti_violation_cab_config
+
+let fleet_operator_kafka_topics = [
+  { mapKey = "city1", mapValue = "city1_kafka_topic" }
+]
 in {
     logger_cfg = logger_cfg,
     redis_cfg = redis_cfg,
@@ -511,5 +515,6 @@ in {
     enable_special_location_bucketing = False,
     queue_position_range_offset = 2,
     queue_exit_hysteresis_threshold = 3,
-    enable_queue_cache_empty_guard = True
+    enable_queue_cache_empty_guard = True,
+    fleet_operator_kafka_topics = fleet_operator_kafka_topics
 }


### PR DESCRIPTION
…rward to kafka based on gtfs_id

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fleet operator as a new supported user type in the location tracking service.
  * Fleet operators can now submit vehicle location updates with GTFS ID and vehicle number information.
  * Location updates are automatically routed to GTFS-specific Kafka topics for processing.
  * Service accepts optional GTFS ID and vehicle number headers when processing fleet operator submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->