### PR TITLE
Special-Location-Queue-Moved-To-Primary-Redis

### DIFF
--- a/crates/location_tracking_service/src/domain/action/internal/location.rs
+++ b/crates/location_tracking_service/src/domain/action/internal/location.rs
@@ -547,8 +547,9 @@ pub async fn driver_queue_position(
     vehicle_type: String,
     driver_id: String,
 ) -> Result<DriverQueuePositionResponse, AppError> {
+    let primary_redis = data.queue_redis();
     let (rank, queue_size) = get_driver_queue_position_and_size(
-        &data.redis,
+        &primary_redis,
         &special_location_id,
         &vehicle_type,
         &driver_id,
@@ -572,11 +573,12 @@ pub async fn driver_queue_history(
     merchant_id: String,
     driver_id: String,
 ) -> Result<DriverQueueHistoryResponse, AppError> {
+    let primary_redis = data.queue_redis();
     // Tracking state and event timeline can be fetched in parallel — neither
     // depends on the other.
     let (tracking, events) = tokio::try_join!(
-        get_driver_queue_tracking(&data.redis, &merchant_id, &driver_id),
-        get_driver_queue_rank_history(&data.redis, &merchant_id, &driver_id),
+        get_driver_queue_tracking(&primary_redis, &merchant_id, &driver_id),
+        get_driver_queue_rank_history(&primary_redis, &merchant_id, &driver_id),
     )?;
 
     // Live ZRANK is only meaningful when we know which queue the driver is in.
@@ -584,7 +586,7 @@ pub async fn driver_queue_history(
     // already tell the story of how they left.
     let current_rank = if let Some(ref t) = tracking {
         get_driver_queue_position(
-            &data.redis,
+            &primary_redis,
             &t.special_location_id,
             &t.vehicle_type,
             &driver_id,
@@ -617,12 +619,24 @@ pub async fn manual_queue_remove(
     driver_id: String,
     reason: Option<String>,
 ) -> Result<APISuccess, AppError> {
-    remove_driver_from_queue(&data.redis, &special_location_id, &vehicle_type, &driver_id).await?;
-    delete_driver_queue_tracking(&data.redis, &merchant_id, &driver_id).await?;
+    let primary_redis = data.queue_redis();
+    remove_driver_from_queue(
+        &primary_redis,
+        &special_location_id,
+        &vehicle_type,
+        &driver_id,
+    )
+    .await?;
+    delete_driver_queue_tracking(&primary_redis, &merchant_id, &driver_id).await?;
     // Clear last_ts so the next in-fence ping cannot resurrect the driver at
     // their original score via the drainer's ZADD-NX-with-stored-ts path.
-    delete_driver_queue_last_ts(&data.redis, &special_location_id, &vehicle_type, &driver_id)
-        .await?;
+    delete_driver_queue_last_ts(
+        &primary_redis,
+        &special_location_id,
+        &vehicle_type,
+        &driver_id,
+    )
+    .await?;
     // Normalize once: empty/whitespace-only reasons collapse to None so the
     // rank-history event and the prometheus label stay in sync.
     let normalized_reason = reason.as_deref().map(str::trim).filter(|r| !r.is_empty());
@@ -635,7 +649,7 @@ pub async fn manual_queue_remove(
         None => "exit:manual".to_string(),
     };
     if let Err(err) = append_rank_history_event(
-        &data.redis,
+        &primary_redis,
         &merchant_id,
         &driver_id,
         Utc::now().timestamp() as f64,
@@ -663,13 +677,14 @@ pub async fn manual_queue_add(
     driver_id: String,
     queue_position: u64, // 1-indexed
 ) -> Result<APISuccess, AppError> {
+    let primary_redis = data.queue_redis();
     // First remove the driver if already in a different queue
     let existing_tracking =
-        get_driver_queue_tracking(&data.redis, &merchant_id, &driver_id).await?;
+        get_driver_queue_tracking(&primary_redis, &merchant_id, &driver_id).await?;
     if let Some(old) = &existing_tracking {
         if old.special_location_id != special_location_id || old.vehicle_type != vehicle_type {
             remove_driver_from_queue(
-                &data.redis,
+                &primary_redis,
                 &old.special_location_id,
                 &old.vehicle_type,
                 &driver_id,
@@ -679,11 +694,17 @@ pub async fn manual_queue_add(
     }
 
     // Also remove from the target queue if already present (to re-insert at new position)
-    remove_driver_from_queue(&data.redis, &special_location_id, &vehicle_type, &driver_id).await?;
+    remove_driver_from_queue(
+        &primary_redis,
+        &special_location_id,
+        &vehicle_type,
+        &driver_id,
+    )
+    .await?;
 
     // Recompute queue size after removal
     let queue_size_after_removal =
-        get_queue_size(&data.redis, &special_location_id, &vehicle_type).await?;
+        get_queue_size(&primary_redis, &special_location_id, &vehicle_type).await?;
 
     // Compute the score for the desired position
     let target_rank = if queue_position == 0 {
@@ -698,7 +719,7 @@ pub async fn manual_queue_add(
     } else if target_rank == 0 {
         // Insert at the front — use score slightly before the first member
         let scores =
-            get_queue_scores_at_range(&data.redis, &special_location_id, &vehicle_type, 0, 0)
+            get_queue_scores_at_range(&primary_redis, &special_location_id, &vehicle_type, 0, 0)
                 .await?;
         if let Some((_, first_score)) = scores.first() {
             first_score - 1.0
@@ -708,9 +729,14 @@ pub async fn manual_queue_add(
     } else if target_rank >= queue_size_after_removal {
         // Insert at the end — use score slightly after the last member
         let last = queue_size_after_removal as i64 - 1;
-        let scores =
-            get_queue_scores_at_range(&data.redis, &special_location_id, &vehicle_type, last, last)
-                .await?;
+        let scores = get_queue_scores_at_range(
+            &primary_redis,
+            &special_location_id,
+            &vehicle_type,
+            last,
+            last,
+        )
+        .await?;
         if let Some((_, last_score)) = scores.first() {
             last_score + 1.0
         } else {
@@ -720,9 +746,14 @@ pub async fn manual_queue_add(
         // Insert between ranks (target_rank - 1) and target_rank
         let before = target_rank as i64 - 1;
         let at = target_rank as i64;
-        let scores =
-            get_queue_scores_at_range(&data.redis, &special_location_id, &vehicle_type, before, at)
-                .await?;
+        let scores = get_queue_scores_at_range(
+            &primary_redis,
+            &special_location_id,
+            &vehicle_type,
+            before,
+            at,
+        )
+        .await?;
         if scores.len() == 2 {
             (scores[0].1 + scores[1].1) / 2.0
         } else {
@@ -731,7 +762,7 @@ pub async fn manual_queue_add(
     };
 
     add_driver_to_queue_force(
-        &data.redis,
+        &primary_redis,
         &special_location_id,
         &vehicle_type,
         &driver_id,
@@ -742,7 +773,7 @@ pub async fn manual_queue_add(
 
     // Set tracking key
     set_driver_queue_tracking(
-        &data.redis,
+        &primary_redis,
         &merchant_id,
         &driver_id,
         &DriverQueueTracking {
@@ -764,8 +795,10 @@ pub async fn get_queue_drivers(
     special_location_id: String,
     vehicle_type: String,
 ) -> Result<QueueDriversResponse, AppError> {
+    let primary_redis = data.queue_redis();
     let scores =
-        get_queue_scores_at_range(&data.redis, &special_location_id, &vehicle_type, 0, -1).await?;
+        get_queue_scores_at_range(&primary_redis, &special_location_id, &vehicle_type, 0, -1)
+            .await?;
     let drivers = scores
         .into_iter()
         .enumerate()
@@ -792,9 +825,10 @@ pub async fn get_special_location_drivers(
     if !data.enable_special_location_bucketing {
         return Ok(SpecialLocationDriversResponse { driver_ids: vec![] });
     }
+    let primary_redis = data.queue_redis();
     let current_bucket = get_bucket_from_timestamp(&data.bucket_size, TimeStamp(Utc::now()));
     let driver_ids = get_drivers_in_special_location(
-        &data.redis,
+        &primary_redis,
         &special_location_id,
         &current_bucket,
         &data.nearby_bucket_threshold,

--- a/crates/location_tracking_service/src/drainer.rs
+++ b/crates/location_tracking_service/src/drainer.rs
@@ -608,6 +608,7 @@ async fn drain_driver_locations(
     queue_exit_hysteresis_threshold: u32,
     entry_ts_ttl: u32,
     redis: &Arc<RedisConnectionPool>,
+    queue_redis: &Arc<RedisConnectionPool>,
 ) {
     info!(
         tag = "[Queued Entries For Draining]",
@@ -627,7 +628,7 @@ async fn drain_driver_locations(
                 .single()
                 .unwrap_or_else(Utc::now);
             if let Err(err) = add_driver_to_special_location_zset(
-                redis,
+                queue_redis,
                 key,
                 *bucket,
                 driver_id,
@@ -643,11 +644,11 @@ async fn drain_driver_locations(
 
     // Fire-and-forget queue actions in a spawned task so they don't block the main drain.
     if !queue_actions.is_empty() {
-        let redis = Arc::clone(redis);
+        let queue_redis = Arc::clone(queue_redis);
         tokio::spawn(async move {
             drain_queue_actions(
                 queue_actions,
-                &redis,
+                &queue_redis,
                 queue_expiry,
                 queue_exit_hysteresis_threshold,
                 entry_ts_ttl,
@@ -714,6 +715,7 @@ pub async fn run_drainer(
     bucket_size: u64,
     near_by_bucket_threshold: u64,
     redis: Arc<RedisConnectionPool>,
+    queue_redis: Arc<RedisConnectionPool>,
     special_location_cache: Option<SpecialLocationCache>,
     enable_special_location_bucketing: bool,
     queue_expiry_seconds: u64,
@@ -748,6 +750,7 @@ pub async fn run_drainer(
                     queue_exit_hysteresis_threshold,
                     special_location_entry_ts_ttl_sec as u32,
                     &redis,
+                    &queue_redis,
                 )
                 .await;
                 cleanup_drainer(
@@ -849,6 +852,7 @@ pub async fn run_drainer(
                                 queue_exit_hysteresis_threshold,
                                 special_location_entry_ts_ttl_sec as u32,
                                 &redis,
+                                &queue_redis,
                             )
                             .await;
                             cleanup_drainer(
@@ -880,6 +884,7 @@ pub async fn run_drainer(
                         queue_exit_hysteresis_threshold,
                         special_location_entry_ts_ttl_sec as u32,
                         &redis,
+                        &queue_redis,
                     )
                     .await;
                     cleanup_drainer(

--- a/crates/location_tracking_service/src/environment.rs
+++ b/crates/location_tracking_service/src/environment.rs
@@ -30,6 +30,7 @@ pub struct AppConfig {
     pub logger_cfg: LoggerConfig,
     pub redis_cfg: RedisConfig,
     pub replica_redis_cfg: Option<RedisConfig>,
+    pub secondary_redis_cfg: Option<RedisConfig>,
     pub zone_to_redis_replica_mapping: Option<HashMap<String, String>>,
     pub workers: usize,
     pub drainer_delay: u64,
@@ -177,6 +178,8 @@ where
 #[derive(Clone)]
 pub struct AppState {
     pub redis: Arc<RedisConnectionPool>,
+    pub secondary_redis: Option<Arc<RedisConnectionPool>>,
+    pub use_secondary_lts_redis: bool,
     pub sender: Sender<(
         Dimensions,
         Latitude,
@@ -259,6 +262,10 @@ impl AppState {
             DriverId,
         )>,
     ) -> AppState {
+        let use_secondary_lts_redis = var("RUN_IN_SECONDARY_LTS_REDIS")
+            .map(|val| val.to_lowercase() == "true")
+            .unwrap_or(false); // default: false — use primary Redis for queue operations
+
         let pod_zone = var("POD_ZONE").ok();
         let new_replica_host = pod_zone
             .as_ref()
@@ -300,6 +307,45 @@ impl AppState {
             .await
             .expect("Failed to create Generic Redis connection pool"),
         );
+
+        let secondary_redis: Option<Arc<RedisConnectionPool>> = match app_config.secondary_redis_cfg
+        {
+            Some(secondary_cfg) => {
+                match RedisConnectionPool::new(
+                    RedisSettings::new(
+                        secondary_cfg.redis_host,
+                        secondary_cfg.redis_port,
+                        secondary_cfg.redis_pool_size,
+                        secondary_cfg.redis_partition,
+                        secondary_cfg.reconnect_max_attempts,
+                        secondary_cfg.reconnect_delay,
+                        secondary_cfg.default_ttl,
+                        secondary_cfg.default_hash_ttl,
+                        secondary_cfg.stream_read_count,
+                        secondary_cfg.broadcast_channel_capacity,
+                    ),
+                    None,
+                )
+                .await
+                {
+                    Ok(pool) => {
+                        info!(
+                            tag = "[Redis Connection]",
+                            "Secondary Redis connected successfully"
+                        );
+                        Some(Arc::new(pool))
+                    }
+                    Err(err) => {
+                        info!(
+                            tag = "[Redis Connection]",
+                            "Error connecting to secondary Redis: {err}"
+                        );
+                        None
+                    }
+                }
+            }
+            None => None,
+        };
 
         let geo_config_path = var("GEO_CONFIG").unwrap_or_else(|_| "./geo_config".to_string());
         let polygons = read_geo_polygon(&geo_config_path).expect("Failed to read geoJSON");
@@ -391,6 +437,8 @@ impl AppState {
 
         AppState {
             redis,
+            secondary_redis,
+            use_secondary_lts_redis,
             drainer_delay: app_config.drainer_delay,
             drainer_size: app_config.drainer_size,
             sender,
@@ -463,5 +511,17 @@ impl AppState {
             enable_queue_cache_empty_guard: app_config.enable_queue_cache_empty_guard,
             special_location_entry_ts_ttl_sec: app_config.special_location_entry_ts_ttl_sec,
         }
+    }
+
+    /// Returns the Redis pool to use for special-location queue operations.
+    /// When `RUN_IN_SECONDARY_LTS_REDIS=true` and a secondary pool is configured,
+    /// returns the secondary pool; otherwise falls back to the primary.
+    pub fn queue_redis(&self) -> Arc<RedisConnectionPool> {
+        if self.use_secondary_lts_redis {
+            if let Some(ref secondary) = self.secondary_redis {
+                return secondary.clone();
+            }
+        }
+        self.redis.clone()
     }
 }

--- a/crates/location_tracking_service/src/environment.rs
+++ b/crates/location_tracking_service/src/environment.rs
@@ -336,7 +336,7 @@ impl AppState {
                         Some(Arc::new(pool))
                     }
                     Err(err) => {
-                        info!(
+                        error!(
                             tag = "[Redis Connection]",
                             "Error connecting to secondary Redis: {err}"
                         );
@@ -391,7 +391,7 @@ impl AppState {
             }
             Err(err) => {
                 producer = None;
-                info!(
+                error!(
                     tag = "[Kafka Connection]",
                     "Error connecting to kafka config: {err}"
                 );
@@ -414,7 +414,7 @@ impl AppState {
                         Some(val)
                     }
                     Err(err) => {
-                        info!(
+                        error!(
                             tag = "[Kafka Connection]",
                             "Error connecting to secondary kafka config: {err}"
                         );

--- a/crates/location_tracking_service/src/main.rs
+++ b/crates/location_tracking_service/src/main.rs
@@ -129,12 +129,13 @@ async fn start_server() -> std::io::Result<()> {
         .await;
     });
 
-    let (drainer_size, drainer_delay, bucket_size, nearby_bucket_threshold, redis) = (
+    let (drainer_size, drainer_delay, bucket_size, nearby_bucket_threshold, redis, queue_redis) = (
         data.drainer_size,
         data.drainer_delay,
         data.bucket_size,
         data.nearby_bucket_threshold,
         data.redis.clone(),
+        data.queue_redis(),
     );
     let special_location_cache = data
         .special_location_list_base_url
@@ -154,6 +155,7 @@ async fn start_server() -> std::io::Result<()> {
             bucket_size,
             nearby_bucket_threshold,
             redis,
+            queue_redis,
             special_location_cache,
             enable_special_location_bucketing,
             queue_expiry_seconds,

--- a/crates/location_tracking_service/src/tools/prometheus.rs
+++ b/crates/location_tracking_service/src/tools/prometheus.rs
@@ -42,17 +42,17 @@ pub static GPS_UPDATES_IGNORED_NO_ACTIVE_RIDE: once_cell::sync::Lazy<IntCounter>
 /// the eviction reason and the source special location.
 ///
 /// Labels:
-/// * `reason`               — `hysteresis` (consecutive_exit_pings reached threshold),
-///                            `switch`     (driver entered a different queue),
-///                            or `manual`  (admin-triggered removal via internal API)
-/// * `special_location_id`  — the queue the driver was evicted from
-/// * `manual_reason`        — sub-reason from the manual-remove request body
-///                            (e.g. `wrong_queue`, `complaint`). Empty string
-///                            for `hysteresis`/`switch` evictions and for
-///                            `manual` evictions where no reason was supplied.
-///                            **Keep the operator vocabulary bounded** — every
-///                            unique string here is a new prometheus time
-///                            series.
+/// * `reason` — `hysteresis` (consecutive_exit_pings reached threshold),
+///   `switch` (driver entered a different queue),
+///   or `manual` (admin-triggered removal via internal API)
+/// * `special_location_id` — the queue the driver was evicted from
+/// * `manual_reason` — sub-reason from the manual-remove request body
+///   (e.g. `wrong_queue`, `complaint`). Empty string
+///   for `hysteresis`/`switch` evictions and for
+///   `manual` evictions where no reason was supplied.
+///   **Keep the operator vocabulary bounded** — every
+///   unique string here is a new prometheus time
+///   series.
 pub static QUEUE_EVICTIONS: once_cell::sync::Lazy<IntCounterVec> = once_cell::sync::Lazy::new(
     || {
         register_int_counter_vec!(

--- a/crates/tests/Cargo.toml
+++ b/crates/tests/Cargo.toml
@@ -3,6 +3,9 @@ name = "tests"
 version = "0.1.0"
 edition = "2021"
 
+[lints.rust]
+unexpected_cfgs = "allow"
+
 [dependencies]
 tokio = "1.28.2"
 futures = "0.3"

--- a/dhall-configs/dev/location_tracking_service.dhall
+++ b/dhall-configs/dev/location_tracking_service.dhall
@@ -22,6 +22,20 @@ let replica_redis_cfg = {
     stream_read_count = 100,
     broadcast_channel_capacity = 10
 }
+
+let secondary_redis_cfg = {
+   redis_host = "localhost",
+    redis_port = 6379,
+    redis_pool_size = 10,
+    redis_partition = 0,
+    reconnect_max_attempts = 10,
+    reconnect_delay = 5000,
+    default_ttl = 3600,
+    default_hash_ttl = 3600,
+    stream_read_count = 100,
+    broadcast_channel_capacity = 10
+}
+
 let zone_to_redis_replica_mapping =
         { ap-south-1a = "0.0.0.0"
         , ap-south-1b = "0.0.0.0"
@@ -454,6 +468,7 @@ in {
     logger_cfg = logger_cfg,
     redis_cfg = redis_cfg,
     replica_redis_cfg = Some replica_redis_cfg,
+    secondary_redis_cfg = Some secondary_redis_cfg,
     zone_to_redis_replica_mapping = Some zone_to_redis_replica_mapping,
     workers = 1,
     drainer_size = 10,


### PR DESCRIPTION
Added Secondary Cluster LTS Redis Connection, if RUN_IN_SECONDARY_LTS_REDIS is true, use secondary cluster redis (So GCP will use AWS redis). But only for special zone queue related operations, everything else will remain in their respective cloud.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Queue operations now use a dedicated Redis instance/pool and the drainer is updated to accept and use it.
  * Added optional secondary Redis configuration and wiring to select it for queue workloads.

* **Documentation**
  * Expanded metric docs with detailed explanations for queue eviction labels and usage guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->