### PR TITLE
LTS - Put Service Port as a main Preference and dhall ports as a fall…

### DIFF
--- a/crates/location_tracking_service/src/main.rs
+++ b/crates/location_tracking_service/src/main.rs
@@ -57,7 +57,10 @@ async fn start_server() -> std::io::Result<()> {
         error!("Panic Occured : {} - {:?}", payload, panic_info);
     }));
 
-    let port = app_config.port;
+    let port = var("SERVICE_PORT")
+        .ok()
+        .and_then(|p| p.parse::<u16>().ok())
+        .unwrap_or(app_config.port);
     let workers = app_config.workers;
     let max_allowed_req_size = app_config.max_allowed_req_size;
 


### PR DESCRIPTION
…back

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The service can now be configured to listen on a custom port via the `SERVICE_PORT` environment variable. If the variable is not provided or invalid, it defaults to the configured port.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nammayatri/location-tracking-service/pull/234?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->