### PR TITLE
feat: consume bus gps pings from bus_driver and bus_conductor instead…

### DIFF
--- a/crates/location_tracking_service/src/domain/action/ui/location.rs
+++ b/crates/location_tracking_service/src/domain/action/ui/location.rs
@@ -127,7 +127,7 @@ async fn get_rider_id_from_authentication(
 }
 
 #[derive(serde::Serialize)]
-struct ConductorGpsUpdate {
+struct BusGpsUpdate {
     #[serde(rename = "deviceId")]
     device_id: String,
     #[serde(rename = "vehicleNo")]
@@ -145,7 +145,11 @@ struct ConductorGpsUpdate {
     provider: &'static str,
 }
 
-pub async fn forward_conductor_locations(
+/// Forward bus-crew pings (`bus_conductor` / `bus_driver`) straight to the
+/// per-fleet Kafka topic keyed by `gtfs_id`, bypassing the driver location
+/// pipeline. Each entry carries its own `person_type`, `gtfs_id` and
+/// `vehicle_no`.
+pub async fn handle_driver_conductor_location_update(
     token: Token,
     data: Data<AppState>,
     request_body: Vec<UpdateDriverLocationRequest>,
@@ -168,9 +172,9 @@ pub async fn forward_conductor_locations(
         .await?
     };
 
-    // Conductor identity reuses the driver auth path; the authenticated
+    // Bus-crew identity reuses the driver auth path; the authenticated
     // person id is recorded as the rate-limit subject.
-    let conductor_person_id = PersonId(driver_id.0.clone());
+    let bus_person_id = PersonId(driver_id.0.clone());
 
     let topic_for_gtfs = |gtfs_id: &str| -> Result<&str, AppError> {
         data.gtfs_id_to_topic
@@ -184,33 +188,41 @@ pub async fn forward_conductor_locations(
     let now_secs = Utc::now().timestamp();
 
     for entry in request_body.into_iter() {
+        let (person_type, provider) = entry
+            .person_type
+            .and_then(|pt| pt.bus_kafka_tags())
+            .ok_or_else(|| {
+                AppError::InvalidRequest(
+                    "person_type must be bus_conductor or bus_driver".to_string(),
+                )
+            })?;
         let gtfs_id = entry.gtfs_id.clone().ok_or_else(|| {
-            AppError::InvalidRequest("gtfs_id required for conductor ping".to_string())
+            AppError::InvalidRequest("gtfs_id required for bus crew ping".to_string())
         })?;
         let vehicle_no = entry.vehicle_no.clone().ok_or_else(|| {
-            AppError::InvalidRequest("vehicle_no required for conductor ping".to_string())
+            AppError::InvalidRequest("vehicle_no required for bus crew ping".to_string())
         })?;
         let topic = topic_for_gtfs(&gtfs_id)?.to_string();
 
         let city = get_city(&entry.pt.lat, &entry.pt.lon, &data.polygon)?;
         sliding_window_limiter(
             &data.redis,
-            &person_rate_limit_key(&merchant_id, &conductor_person_id, &city),
+            &person_rate_limit_key(&merchant_id, &bus_person_id, &city),
             data.location_update_limit,
             data.location_update_interval as u32,
         )
         .await?;
 
-        let payload = ConductorGpsUpdate {
+        let payload = BusGpsUpdate {
             device_id: format!("{gtfs_id}:{vehicle_no}"),
             vehicle_no: vehicle_no.clone(),
-            person_type: "conductor",
+            person_type,
             gtfs_id,
             lat: entry.pt.lat.0,
             lon: entry.pt.lon.0,
             timestamp: entry.ts.0.timestamp(),
             server_time: now_secs,
-            provider: "lts-conductor",
+            provider,
         };
 
         if let Err(e) = crate::common::kafka::push_to_kafka(
@@ -223,7 +235,7 @@ pub async fn forward_conductor_locations(
         .await
         {
             error!(
-                "conductor forward failed (topic={}, vehicle={}): {:?}",
+                "bus crew forward failed (topic={}, vehicle={}): {:?}",
                 topic, vehicle_no, e
             );
         }
@@ -1607,9 +1619,9 @@ pub async fn update_person_location(
             "Generic update_person_location does not support driver; use existing driver API"
                 .to_string(),
         )),
-        PersonType::Conductor => Err(AppError::InvalidRequest(
-            "Generic update_person_location does not support conductor; \
-             use /ui/driver/location with person_type=conductor"
+        PersonType::BusConductor | PersonType::BusDriver => Err(AppError::InvalidRequest(
+            "Generic update_person_location does not support bus crew; \
+             use /ui/driver/location with person_type=bus_conductor or bus_driver"
                 .to_string(),
         )),
     }

--- a/crates/location_tracking_service/src/domain/api/ui/location.rs
+++ b/crates/location_tracking_service/src/domain/api/ui/location.rs
@@ -42,11 +42,12 @@ pub async fn update_driver_location(
             "token (Header) not found".to_string(),
         ))?;
 
-    if matches!(
-        request_body.first().and_then(|r| r.person_type),
-        Some(crate::domain::types::ui::location::PersonType::Conductor)
-    ) {
-        return crate::domain::action::ui::location::forward_conductor_locations(
+    if request_body
+        .first()
+        .and_then(|r| r.person_type)
+        .is_some_and(|pt| pt.is_bus_crew())
+    {
+        return location::handle_driver_conductor_location_update(
             Token(token.clone()),
             data,
             request_body,

--- a/crates/location_tracking_service/src/domain/types/ui/location.rs
+++ b/crates/location_tracking_service/src/domain/types/ui/location.rs
@@ -9,13 +9,14 @@ use crate::common::types::*;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
-/// Person type for generic location APIs (rider, driver, or conductor).
+/// Person type for generic location APIs (rider, driver, or bus crew).
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "snake_case")]
 pub enum PersonType {
     Rider,
     Driver,
-    Conductor,
+    BusConductor,
+    BusDriver,
 }
 
 impl FromStr for PersonType {
@@ -25,7 +26,8 @@ impl FromStr for PersonType {
         match s.to_lowercase().as_str() {
             "rider" => Ok(PersonType::Rider),
             "driver" => Ok(PersonType::Driver),
-            "conductor" => Ok(PersonType::Conductor),
+            "bus_conductor" => Ok(PersonType::BusConductor),
+            "bus_driver" => Ok(PersonType::BusDriver),
             _ => Err(()),
         }
     }
@@ -36,7 +38,24 @@ impl PersonType {
         match self {
             PersonType::Rider => "rider",
             PersonType::Driver => "driver",
-            PersonType::Conductor => "conductor",
+            PersonType::BusConductor => "bus_conductor",
+            PersonType::BusDriver => "bus_driver",
+        }
+    }
+
+    /// True for bus crew pings (`bus_conductor` / `bus_driver`) that are
+    /// forwarded to the per-fleet Kafka topic instead of running the
+    /// driver location pipeline.
+    pub fn is_bus_crew(&self) -> bool {
+        matches!(self, PersonType::BusConductor | PersonType::BusDriver)
+    }
+
+    /// `(person_type, provider)` strings carried in the forwarded Kafka payload.
+    pub fn bus_kafka_tags(&self) -> Option<(&'static str, &'static str)> {
+        match self {
+            PersonType::BusConductor => Some(("bus_conductor", "lts-bus-conductor")),
+            PersonType::BusDriver => Some(("bus_driver", "lts-bus-driver")),
+            _ => None,
         }
     }
 }
@@ -77,9 +96,9 @@ pub struct UpdateDriverLocationRequest {
     pub acc: Option<Accuracy>,
     pub v: Option<SpeedInMeterPerSecond>,
     pub bear: Option<Direction>,
-    /// Optional. When set to `Conductor` together with `gtfs_id` and
-    /// `vehicle_no`, the handler forwards the ping to the Kafka topic
-    /// configured for that fleet instead of running the driver flow.
+    /// Optional. When set to `"bus_conductor"` / `"bus_driver"` together with
+    /// `gtfs_id` and `vehicle_no`, the handler forwards the ping to the Kafka
+    /// topic configured for that fleet instead of running the driver flow.
     /// Absent → existing driver path.
     pub person_type: Option<PersonType>,
     pub gtfs_id: Option<String>,
@@ -127,4 +146,55 @@ pub struct PersonLocationResponse {
     pub curr_point: Point,
     pub last_update: TimeStamp,
     pub accuracy: Option<Accuracy>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn person_type_wire_values_round_trip() {
+        let cases = [
+            (PersonType::Rider, "\"rider\""),
+            (PersonType::Driver, "\"driver\""),
+            (PersonType::BusConductor, "\"bus_conductor\""),
+            (PersonType::BusDriver, "\"bus_driver\""),
+        ];
+        for (variant, wire) in cases {
+            assert_eq!(serde_json::to_string(&variant).ok(), Some(wire.to_string()));
+            assert_eq!(
+                serde_json::from_str::<PersonType>(wire).ok(),
+                Some(variant),
+                "deserialize {wire}"
+            );
+            // FromStr (path params) must agree with the serde wire value.
+            let bare = wire.trim_matches('"');
+            assert_eq!(PersonType::from_str(bare).ok(), Some(variant));
+            assert_eq!(variant.as_str(), bare);
+        }
+    }
+
+    #[test]
+    fn legacy_conductor_value_is_rejected() {
+        // `conductor` was intentionally removed; it must no longer parse.
+        assert!(serde_json::from_str::<PersonType>("\"conductor\"").is_err());
+        assert!(PersonType::from_str("conductor").is_err());
+    }
+
+    #[test]
+    fn bus_kafka_tags_only_for_bus_crew() {
+        assert_eq!(
+            PersonType::BusConductor.bus_kafka_tags(),
+            Some(("bus_conductor", "lts-bus-conductor"))
+        );
+        assert_eq!(
+            PersonType::BusDriver.bus_kafka_tags(),
+            Some(("bus_driver", "lts-bus-driver"))
+        );
+        assert_eq!(PersonType::Driver.bus_kafka_tags(), None);
+        assert_eq!(PersonType::Rider.bus_kafka_tags(), None);
+        assert!(PersonType::BusConductor.is_bus_crew());
+        assert!(PersonType::BusDriver.is_bus_crew());
+        assert!(!PersonType::Driver.is_bus_crew());
+    }
 }


### PR DESCRIPTION
… of conductor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bus crew (drivers/conductors) GPS pings are now forwarded to per-fleet location streams for proper fleet-level handling.

* **Bug Fixes**
  * Bus crew location updates are correctly routed through the dedicated driver location path, fixing mis-segmentation of GPS data.

* **Improvements**
  * Generic location endpoint now rejects bus crew types with a clear error directing them to the driver location endpoint; new person-type distinctions added for bus crew.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nammayatri/location-tracking-service/pull/236?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->