### PR TITLE
refactor: move gtfs_id, person_type, vehicle_no fields to headers to …

### DIFF
--- a/crates/location_tracking_service/src/domain/action/external/gps.rs
+++ b/crates/location_tracking_service/src/domain/action/external/gps.rs
@@ -203,9 +203,6 @@ fn convert_gps_to_location_updates(
             v: speed,
             acc: None,
             bear: bearing,
-            person_type: None,
-            gtfs_id: None,
-            vehicle_no: None,
         });
     }
 

--- a/crates/location_tracking_service/src/domain/action/ui/location.rs
+++ b/crates/location_tracking_service/src/domain/action/ui/location.rs
@@ -147,13 +147,15 @@ struct BusGpsUpdate {
 
 /// Forward bus-crew pings (`bus_conductor` / `bus_driver`) straight to the
 /// per-fleet Kafka topic keyed by `gtfs_id`, bypassing the driver location
-/// pipeline. Each entry carries its own `person_type`, `gtfs_id` and
-/// `vehicle_no`.
+/// pipeline. `person_type`, `gtfs_id` and `vehicle_no` are passed as headers.
 pub async fn handle_driver_conductor_location_update(
     token: Token,
     data: Data<AppState>,
     request_body: Vec<UpdateDriverLocationRequest>,
     req_merchant_id: Option<MerchantId>,
+    person_type_value: PersonType,
+    gtfs_id: String,
+    vehicle_no: String,
 ) -> Result<(), AppError> {
     let (driver_id, merchant_id, _moc_id) = if var("DEV").is_ok() {
         (
@@ -187,23 +189,12 @@ pub async fn handle_driver_conductor_location_update(
 
     let now_secs = Utc::now().timestamp();
 
-    for entry in request_body.into_iter() {
-        let (person_type, provider) = entry
-            .person_type
-            .and_then(|pt| pt.bus_kafka_tags())
-            .ok_or_else(|| {
-                AppError::InvalidRequest(
-                    "person_type must be bus_conductor or bus_driver".to_string(),
-                )
-            })?;
-        let gtfs_id = entry.gtfs_id.clone().ok_or_else(|| {
-            AppError::InvalidRequest("gtfs_id required for bus crew ping".to_string())
-        })?;
-        let vehicle_no = entry.vehicle_no.clone().ok_or_else(|| {
-            AppError::InvalidRequest("vehicle_no required for bus crew ping".to_string())
-        })?;
-        let topic = topic_for_gtfs(&gtfs_id)?.to_string();
+    let (person_type_tag, provider) = person_type_value.bus_kafka_tags().ok_or_else(|| {
+        AppError::InvalidRequest("person_type must be bus_conductor or bus_driver".to_string())
+    })?;
+    let topic = topic_for_gtfs(&gtfs_id)?.to_string();
 
+    for entry in request_body.into_iter() {
         let city = get_city(&entry.pt.lat, &entry.pt.lon, &data.polygon)?;
         sliding_window_limiter(
             &data.redis,
@@ -216,8 +207,8 @@ pub async fn handle_driver_conductor_location_update(
         let payload = BusGpsUpdate {
             device_id: format!("{gtfs_id}:{vehicle_no}"),
             vehicle_no: vehicle_no.clone(),
-            person_type,
-            gtfs_id,
+            person_type: person_type_tag,
+            gtfs_id: gtfs_id.clone(),
             lat: entry.pt.lat.0,
             lon: entry.pt.lon.0,
             timestamp: entry.ts.0.timestamp(),

--- a/crates/location_tracking_service/src/domain/api/ui/location.rs
+++ b/crates/location_tracking_service/src/domain/api/ui/location.rs
@@ -42,19 +42,42 @@ pub async fn update_driver_location(
             "token (Header) not found".to_string(),
         ))?;
 
-    if request_body
-        .first()
-        .and_then(|r| r.person_type)
-        .is_some_and(|pt| pt.is_bus_crew())
+    if let Some(person_type) = req
+        .headers()
+        .get("person-type")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| PersonType::from_str(s).ok())
+        .filter(|pt| pt.is_bus_crew())
     {
+        let gtfs_id = req
+            .headers()
+            .get("gtfs-id")
+            .and_then(|v| v.to_str().ok())
+            .map(String::from)
+            .ok_or(AppError::InvalidRequest(
+                "gtfs-id (Header) required for bus crew".to_string(),
+            ))?;
+        let vehicle_no = req
+            .headers()
+            .get("vehicle-no")
+            .and_then(|v| v.to_str().ok())
+            .map(String::from)
+            .ok_or(AppError::InvalidRequest(
+                "vehicle-no (Header) required for bus crew".to_string(),
+            ))?;
+        let req_merchant_id = req
+            .headers()
+            .get("mid")
+            .and_then(|v| v.to_str().ok())
+            .map(|s| MerchantId(s.to_string()));
         return location::handle_driver_conductor_location_update(
             Token(token.clone()),
             data,
             request_body,
-            req.headers()
-                .get("mid")
-                .and_then(|v| v.to_str().ok())
-                .map(|s| MerchantId(s.to_string())),
+            req_merchant_id,
+            person_type,
+            gtfs_id,
+            vehicle_no,
         )
         .await
         .map(|_| HttpResponse::Ok().finish());

--- a/crates/location_tracking_service/src/domain/types/ui/location.rs
+++ b/crates/location_tracking_service/src/domain/types/ui/location.rs
@@ -96,13 +96,6 @@ pub struct UpdateDriverLocationRequest {
     pub acc: Option<Accuracy>,
     pub v: Option<SpeedInMeterPerSecond>,
     pub bear: Option<Direction>,
-    /// Optional. When set to `"bus_conductor"` / `"bus_driver"` together with
-    /// `gtfs_id` and `vehicle_no`, the handler forwards the ping to the Kafka
-    /// topic configured for that fleet instead of running the driver flow.
-    /// Absent → existing driver path.
-    pub person_type: Option<PersonType>,
-    pub gtfs_id: Option<String>,
-    pub vehicle_no: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]


### PR DESCRIPTION
…remove redundancy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated bus-crew identity handling to request-level headers instead of per-entry fields.
  * Request payloads now carry only core location data (position, timestamp, velocity, accuracy, bearing); identity (person type, GTFS ID, vehicle no.) is parsed and applied once per request.
  * Simplified internal location update assembly for leaner, clearer payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->