### PR TITLE
enhc: disabling queue for driver based on enableForAirport

### DIFF
--- a/crates/location_tracking_service/src/drainer.rs
+++ b/crates/location_tracking_service/src/drainer.rs
@@ -15,9 +15,10 @@ use crate::{
     },
     redis::{
         commands::{
-            add_driver_to_special_location_zset, batch_get_driver_queue_last_ts,
-            batch_get_driver_queue_trackings, push_drainer_driver_location, rank_history_payload,
-            DriverQueueTracking, RANK_HISTORY_TTL_SECS,
+            add_driver_to_special_location_zset, batch_get_driver_airport_restriction,
+            batch_get_driver_queue_last_ts, batch_get_driver_queue_trackings,
+            push_drainer_driver_location, rank_history_payload, DriverQueueTracking,
+            RANK_HISTORY_TTL_SECS,
         },
         keys::{
             driver_loc_bucket_key, driver_queue_last_ts_key, driver_queue_rank_history_key,
@@ -147,9 +148,21 @@ async fn drain_queue_actions(
         })
         .collect();
 
-    let (trackings, last_ts_results) = tokio::join!(
+    // Airport-queue gating: for each Enter action we need the driver's
+    // `enableForAirport` flag. PossibleExit slots are None (no enqueue
+    // happens), so they're skipped in the MGET but kept aligned to `actions`.
+    let enter_driver_ids: Vec<Option<&str>> = actions
+        .iter()
+        .map(|a| match a {
+            QueueAction::Enter { driver_id, .. } => Some(driver_id.as_str()),
+            QueueAction::PossibleExit { .. } => None,
+        })
+        .collect();
+
+    let (trackings, last_ts_results, airport_restrictions) = tokio::join!(
         batch_get_driver_queue_trackings(redis, &pairs),
-        batch_get_driver_queue_last_ts(redis, &last_ts_triples)
+        batch_get_driver_queue_last_ts(redis, &last_ts_triples),
+        batch_get_driver_airport_restriction(redis, &enter_driver_ids)
     );
 
     let trackings = match trackings {
@@ -168,13 +181,25 @@ async fn drain_queue_actions(
         }
     };
 
+    // Fail-open: if the pool-data MGET errors we can't tell who's restricted,
+    // so allow everyone into the queue (None = allowed) rather than blocking
+    // the whole batch.
+    let airport_restrictions = match airport_restrictions {
+        Ok(v) => v,
+        Err(e) => {
+            error!(tag = "[Queue Batch Airport Restriction MGET]", error = %e);
+            vec![None; actions.len()]
+        }
+    };
+
     // Step 2: Build all write commands into a single pipeline
     let pipeline = redis.writer_pool.next().pipeline();
 
-    for ((action, old_tracking), stored_last_ts) in actions
+    for (((action, old_tracking), stored_last_ts), airport_restriction) in actions
         .iter()
         .zip(trackings.iter())
         .zip(last_ts_results.iter())
+        .zip(airport_restrictions.iter())
     {
         match action {
             QueueAction::Enter {
@@ -184,6 +209,24 @@ async fn drain_queue_actions(
                 vehicle_type,
                 timestamp,
             } => {
+                // Airport-queue gating: only drivers explicitly ENABLED for
+                // the airport may enter. DISABLED/BLOCKED are kept out. Missing
+                // / unreadable pool-data is fail-open (None → allowed). This
+                // only blocks *new* entries — a driver already in the queue who
+                // becomes restricted stays until they leave the geofence.
+                if airport_restriction.is_some_and(|r| r.is_airport_queue_blocked()) {
+                    info!(
+                        tag = "[Queue Enter Blocked]",
+                        driver_id = %driver_id,
+                        merchant_id = %merchant_id,
+                        special_location_id = %special_location_id,
+                        vehicle_type = %vehicle_type,
+                        restriction = ?airport_restriction,
+                        "Driver not ENABLED for airport queue; skipping enqueue"
+                    );
+                    continue;
+                }
+
                 // True only if prior tracking exists AND points at this same
                 // queue. Drives both (1) carry-forward of last_recorded_rank
                 // for HSET dedup and (2) the queue-switch eviction below.

--- a/crates/location_tracking_service/src/redis/commands.rs
+++ b/crates/location_tracking_service/src/redis/commands.rs
@@ -1255,6 +1255,41 @@ pub struct DriverQueueTracking {
     pub last_recorded_rank: Option<u64>,
 }
 
+/// Airport-queue eligibility flag stored on the driver's `driver-pool-data`
+/// (field `enableForAirport`), written by the driver-app backend. The backend
+/// serializes the Haskell enum `AirportRestrictionType` as a bare JSON string
+/// (`"ENABLED"` / `"DISABLED"` / `"BLOCKED"`). `Unknown` is a forward-compat
+/// catch-all so an unexpected value never fails the whole MGET batch.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AirportRestrictionType {
+    #[serde(rename = "ENABLED")]
+    Enabled,
+    #[serde(rename = "DISABLED")]
+    Disabled,
+    #[serde(rename = "BLOCKED")]
+    Blocked,
+    #[serde(other)]
+    Unknown,
+}
+
+impl AirportRestrictionType {
+    /// A driver is barred from the airport queue only when explicitly
+    /// DISABLED or BLOCKED. ENABLED and any unknown/forward-compat value are
+    /// treated as allowed (fail-open), matching the missing-data behaviour in
+    /// `batch_get_driver_airport_restriction`.
+    pub fn is_airport_queue_blocked(&self) -> bool {
+        matches!(self, Self::Disabled | Self::Blocked)
+    }
+}
+
+/// Minimal view over `driver-pool-data` — we only read the airport flag and
+/// let serde ignore every other field the backend stores there.
+#[derive(Deserialize, Debug)]
+pub struct DriverPoolAirportData {
+    #[serde(rename = "enableForAirport", default)]
+    pub enable_for_airport: Option<AirportRestrictionType>,
+}
+
 /// TTL applied to the per-driver rank-history list on every event write.
 /// 24h gives operators a full day to inspect rank churn while debugging,
 /// at the cost of more per-key memory for large fleets.
@@ -1522,6 +1557,44 @@ pub async fn batch_get_driver_queue_trackings(
         .mget_keys::<DriverQueueTracking>(keys)
         .await
         .map_err(|err| AppError::InternalError(err.to_string()))
+}
+
+/// Batch-fetch the airport-queue eligibility flag (`enableForAirport`) from
+/// each driver's `driver-pool-data`. `driver_ids` is sparse — `None` slots
+/// (e.g. PossibleExit actions, which never enqueue) are skipped in the MGET
+/// but kept in the returned vector so callers can zip it 1-to-1 against their
+/// action list.
+///
+/// A slot resolves to `None` when the key is absent or the field is
+/// missing/null; callers treat that as "allowed" (fail-open). Only the
+/// `enableForAirport` field is read — all other pool-data fields are ignored.
+pub async fn batch_get_driver_airport_restriction(
+    redis: &RedisConnectionPool,
+    driver_ids: &[Option<&str>],
+) -> Result<Vec<Option<AirportRestrictionType>>, AppError> {
+    if driver_ids.is_empty() {
+        return Ok(vec![]);
+    }
+    let mut keys: Vec<String> = Vec::with_capacity(driver_ids.len());
+    let mut slots: Vec<usize> = Vec::with_capacity(driver_ids.len());
+    for (idx, d) in driver_ids.iter().enumerate() {
+        if let Some(driver_id) = d {
+            keys.push(driver_pool_data_key(driver_id));
+            slots.push(idx);
+        }
+    }
+    if keys.is_empty() {
+        return Ok(vec![None; driver_ids.len()]);
+    }
+    let raw: Vec<Option<DriverPoolAirportData>> = redis
+        .mget_keys::<DriverPoolAirportData>(keys)
+        .await
+        .map_err(|err| AppError::InternalError(err.to_string()))?;
+    let mut out: Vec<Option<AirportRestrictionType>> = vec![None; driver_ids.len()];
+    for (slot, val) in slots.into_iter().zip(raw.into_iter()) {
+        out[slot] = val.and_then(|d| d.enable_for_airport);
+    }
+    Ok(out)
 }
 
 pub async fn batch_check_drivers_on_ride(

--- a/crates/location_tracking_service/src/redis/keys.rs
+++ b/crates/location_tracking_service/src/redis/keys.rs
@@ -296,6 +296,16 @@ pub fn driver_queue_tracking_key(merchant_id: &str, driver_id: &str) -> String {
     format!("lts:driver_queue:{}:{}", merchant_id, driver_id)
 }
 
+/// Key holding a driver's pool data, written by the driver-app (BPP) backend
+/// and synced into the LTS-accessible Redis. We only read it here to gate
+/// airport-queue entry on the `enableForAirport` flag.
+///
+/// IMPORTANT: this must match the backend's `driverPoolDataKey` exactly —
+/// it has NO `lts:` prefix.
+pub fn driver_pool_data_key(driver_id: &str) -> String {
+    format!("driver-pool-data:{driver_id}")
+}
+
 /// Per-driver rolling Redis LIST of recent queue rank events. Each entry is
 /// a JSON object `{"ts": <server_timestamp>, "event": <string>}`, LPUSH'd at
 /// write time so reads are newest-first without an explicit sort. The event


### PR DESCRIPTION
Not letting Drivers entering in the Airport queue if the `enableForAirport` flag is not `ENABLED`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added airport queue eligibility verification that gates driver entry based on restriction status
  * Drivers are now checked against airport restrictions before being permitted to enter airport queues
  * System gracefully handles data retrieval failures by defaulting to allowing queue entry

<!-- end of auto-generated comment: release notes by coderabbit.ai -->