### PR TITLE
fix: redis port fix

### DIFF
--- a/dhall-configs/dev/location_tracking_service.dhall
+++ b/dhall-configs/dev/location_tracking_service.dhall
@@ -1,6 +1,6 @@
 let redis_cfg = {
     redis_host = "localhost",
-    redis_port = 6379,
+    redis_port = 6380,
     redis_pool_size = 10,
     redis_partition = 0,
     reconnect_max_attempts = 10,
@@ -12,7 +12,7 @@ let redis_cfg = {
 }
 let replica_redis_cfg = {
     redis_host = "localhost",
-    redis_port = 6379,
+    redis_port = 6380,
     redis_pool_size = 10,
     redis_partition = 0,
     reconnect_max_attempts = 10,
@@ -25,7 +25,7 @@ let replica_redis_cfg = {
 
 let secondary_redis_cfg = {
    redis_host = "localhost",
-    redis_port = 6379,
+    redis_port = 6381,
     redis_pool_size = 10,
     redis_partition = 0,
     reconnect_max_attempts = 10,


### PR DESCRIPTION
LTS local server listening to wrong redid port fixed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated development Redis port settings for primary, replica, and secondary services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->