### PR TITLE
feat: route driver location updates to merchant's cloud via auth cloudType

### DIFF
--- a/crates/location_tracking_service/src/common/types.rs
+++ b/crates/location_tracking_service/src/common/types.rs
@@ -271,6 +271,11 @@ pub enum DriverMode {
 pub enum CloudType {
     AWS,
     GCP,
+    /// `serde(other)`: any cloud value this LTS build doesn't know (e.g. a
+    /// newer driver-app adds a variant) deserializes here instead of failing
+    /// the whole auth response, which would black out the driver's pings.
+    /// UNAVAILABLE never forwards, so unknown clouds process locally.
+    #[serde(other)]
     UNAVAILABLE,
 }
 

--- a/crates/location_tracking_service/src/common/types.rs
+++ b/crates/location_tracking_service/src/common/types.rs
@@ -264,6 +264,16 @@ pub enum DriverMode {
     SILENT,
 }
 
+/// Cloud a merchant's traffic is homed in, as reported by the driver-app
+/// internal auth endpoint (`cloudType`). Used to route driver location
+/// updates to the LTS deployment of the owning cloud.
+#[derive(Debug, Clone, Copy, EnumString, Display, Serialize, Deserialize, Eq, Hash, PartialEq)]
+pub enum CloudType {
+    AWS,
+    GCP,
+    UNAVAILABLE,
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct APISuccess {
     result: String,
@@ -282,6 +292,10 @@ pub struct AuthData {
     pub driver_id: DriverId,
     pub merchant_id: MerchantId,
     pub merchant_operating_city_id: MerchantOperatingCityId,
+    /// Cloud owning this merchant's traffic. `#[serde(default)]` keeps
+    /// backward compatibility with Redis entries cached before this field existed.
+    #[serde(default)]
+    pub cloud_type: Option<CloudType>,
 }
 
 pub struct DriverLocationPoint {

--- a/crates/location_tracking_service/src/domain/action/ui/location.rs
+++ b/crates/location_tracking_service/src/domain/action/ui/location.rs
@@ -25,7 +25,8 @@ use crate::outbound::external::get_distance_matrix;
 use crate::outbound::external::trigger_detection_alert;
 use crate::outbound::external::{
     authenticate_bap, authenticate_dobpp, bulk_location_update_dobpp, driver_reached_destination,
-    trigger_fcm_bap, trigger_fcm_dobpp, trigger_stop_detection_event,
+    forward_driver_location_to_cloud, trigger_fcm_bap, trigger_fcm_dobpp,
+    trigger_stop_detection_event,
 };
 use crate::outbound::types::{LocationUpdate, ViolationDetectionReq};
 use crate::redis::{commands::*, keys::*};
@@ -53,12 +54,21 @@ async fn get_driver_id_from_authentication(
     auth_api_key: &str,
     auth_token_expiry: &u32,
     token: &Token,
-) -> Result<(DriverId, MerchantId, MerchantOperatingCityId), AppError> {
+) -> Result<
+    (
+        DriverId,
+        MerchantId,
+        MerchantOperatingCityId,
+        Option<CloudType>,
+    ),
+    AppError,
+> {
     match get_driver_id(redis, token).await? {
         Some(auth_data) => Ok((
             auth_data.driver_id,
             auth_data.merchant_id,
             auth_data.merchant_operating_city_id,
+            auth_data.cloud_type,
         )),
         None => {
             let response = authenticate_dobpp(auth_url, token.0.as_str(), auth_api_key).await?;
@@ -69,12 +79,14 @@ async fn get_driver_id_from_authentication(
                 response.driver_id.to_owned(),
                 response.merchant_id.to_owned(),
                 response.merchant_operating_city_id.to_owned(),
+                response.cloud_type,
             )
             .await?;
             Ok((
                 response.driver_id,
                 response.merchant_id,
                 response.merchant_operating_city_id,
+                response.cloud_type,
             ))
         }
     }
@@ -157,11 +169,13 @@ pub async fn handle_driver_conductor_location_update(
     gtfs_id: String,
     vehicle_no: String,
 ) -> Result<(), AppError> {
-    let (driver_id, merchant_id, _moc_id) = if var("DEV").is_ok() {
+    // Bus-crew path always processes locally, so the cloud_type from auth is ignored.
+    let (driver_id, merchant_id, _moc_id, _cloud_type) = if var("DEV").is_ok() {
         (
             DriverId(token.to_owned().inner()),
             req_merchant_id.unwrap_or_else(|| MerchantId("dev".to_string())),
             MerchantOperatingCityId("dev".to_string()),
+            None,
         )
     } else {
         get_driver_id_from_authentication(
@@ -277,13 +291,17 @@ pub async fn update_driver_location_by_token(
     group_id: Option<String>,
     group_id2: Option<String>,
     req_merchant_id: Option<MerchantId>,
+    is_forwarded_request: bool,
 ) -> Result<HttpResponse, AppError> {
     let current_ts = Utc::now();
-    let (driver_id, merchant_id, merchant_operating_city_id) = if var("DEV").is_ok() {
+    let (driver_id, merchant_id, merchant_operating_city_id, cloud_type) = if var("DEV").is_ok() {
         (
             DriverId(token.to_owned().inner()),
-            req_merchant_id.unwrap_or_else(|| MerchantId("dev".to_string())),
+            req_merchant_id
+                .clone()
+                .unwrap_or_else(|| MerchantId("dev".to_string())),
             MerchantOperatingCityId("dev".to_string()),
+            None,
         )
     } else {
         get_driver_id_from_authentication(
@@ -295,6 +313,38 @@ pub async fn update_driver_location_by_token(
         )
         .await?
     };
+
+    // Cross-cloud routing: if the merchant's cloud (from auth) differs from
+    // the cloud this LTS runs in, forward the raw request to the owning
+    // cloud's LTS and skip local processing. The `is_forwarded_request` loop
+    // guard ensures the receiving side always processes locally.
+    if !is_forwarded_request {
+        if let Some(cloud) = cloud_type {
+            if cloud != CloudType::UNAVAILABLE && cloud != data.cloud_type {
+                if let Some(url) = data.cloud_lts_url_mapping.get(&cloud) {
+                    info!(
+                        tag = "[Cross Cloud Forwarding]",
+                        "Forwarding location update for Driver Id : {:?} to driver cloud {} from current cloud {}",
+                        &driver_id,
+                        cloud,
+                        data.cloud_type
+                    );
+                    forward_driver_location_to_cloud(
+                        url,
+                        token.0.as_str(),
+                        &vehicle_type,
+                        &driver_mode,
+                        req_merchant_id.as_ref(),
+                        group_id.as_deref(),
+                        group_id2.as_deref(),
+                        &locations,
+                    )
+                    .await?;
+                    return Ok(HttpResponse::Ok().finish());
+                }
+            }
+        }
+    }
 
     if locations.len() > data.batch_size as usize {
         warn!(

--- a/crates/location_tracking_service/src/domain/action/ui/location.rs
+++ b/crates/location_tracking_service/src/domain/action/ui/location.rs
@@ -320,7 +320,10 @@ pub async fn update_driver_location_by_token(
     // guard ensures the receiving side always processes locally.
     if !is_forwarded_request {
         if let Some(cloud) = cloud_type {
-            if cloud != CloudType::UNAVAILABLE && cloud != data.cloud_type {
+            if data.cloud_type != CloudType::UNAVAILABLE
+                && cloud != CloudType::UNAVAILABLE
+                && cloud != data.cloud_type
+            {
                 if let Some(url) = data.cloud_lts_url_mapping.get(&cloud) {
                     info!(
                         tag = "[Cross Cloud Forwarding]",

--- a/crates/location_tracking_service/src/domain/action/ui/location.rs
+++ b/crates/location_tracking_service/src/domain/action/ui/location.rs
@@ -291,9 +291,14 @@ pub async fn update_driver_location_by_token(
     group_id: Option<String>,
     group_id2: Option<String>,
     req_merchant_id: Option<MerchantId>,
-    is_forwarded_request: bool,
+    req_headers: Vec<(String, String)>,
 ) -> Result<HttpResponse, AppError> {
     let current_ts = Utc::now();
+    // Loop guard set by a sibling LTS deployment that forwarded this request
+    // from another cloud — process locally instead of forwarding again.
+    let is_forwarded_request = req_headers.iter().any(|(name, value)| {
+        name.eq_ignore_ascii_case("x-forwarded-from-cloud") && value == "true"
+    });
     let (driver_id, merchant_id, merchant_operating_city_id, cloud_type) = if var("DEV").is_ok() {
         (
             DriverId(token.to_owned().inner()),
@@ -332,17 +337,7 @@ pub async fn update_driver_location_by_token(
                         cloud,
                         data.cloud_type
                     );
-                    forward_driver_location_to_cloud(
-                        url,
-                        token.0.as_str(),
-                        &vehicle_type,
-                        &driver_mode,
-                        req_merchant_id.as_ref(),
-                        group_id.as_deref(),
-                        group_id2.as_deref(),
-                        &locations,
-                    )
-                    .await?;
+                    forward_driver_location_to_cloud(url, &req_headers, &locations).await?;
                     return Ok(HttpResponse::Ok().finish());
                 }
             }

--- a/crates/location_tracking_service/src/domain/api/ui/location.rs
+++ b/crates/location_tracking_service/src/domain/api/ui/location.rs
@@ -119,6 +119,15 @@ pub async fn update_driver_location(
         .and_then(|header_value| header_value.to_str().ok())
         .map(|mid_str| MerchantId(mid_str.to_string()));
 
+    // Loop guard set by a sibling LTS deployment that forwarded this request
+    // from another cloud — process locally instead of forwarding again.
+    let is_forwarded_request = req
+        .headers()
+        .get("x-forwarded-from-cloud")
+        .and_then(|header_value| header_value.to_str().ok())
+        .map(|value| value == "true")
+        .unwrap_or(false);
+
     location::update_driver_location_by_token(
         Token(token),
         vehicle_type,
@@ -128,6 +137,7 @@ pub async fn update_driver_location(
         group_id,
         group_id2,
         req_merchant_id,
+        is_forwarded_request,
     )
     .await?;
     Ok(HttpResponse::Ok().finish())

--- a/crates/location_tracking_service/src/domain/api/ui/location.rs
+++ b/crates/location_tracking_service/src/domain/api/ui/location.rs
@@ -119,14 +119,19 @@ pub async fn update_driver_location(
         .and_then(|header_value| header_value.to_str().ok())
         .map(|mid_str| MerchantId(mid_str.to_string()));
 
-    // Loop guard set by a sibling LTS deployment that forwarded this request
-    // from another cloud — process locally instead of forwarding again.
-    let is_forwarded_request = req
+    // Full header set, passed through as-is on a cross-cloud forward so
+    // headers added to this API in the future are never silently dropped.
+    // Also carries the x-forwarded-from-cloud loop-guard flag.
+    let req_headers: Vec<(String, String)> = req
         .headers()
-        .get("x-forwarded-from-cloud")
-        .and_then(|header_value| header_value.to_str().ok())
-        .map(|value| value == "true")
-        .unwrap_or(false);
+        .iter()
+        .filter_map(|(name, value)| {
+            value
+                .to_str()
+                .ok()
+                .map(|value| (name.as_str().to_string(), value.to_string()))
+        })
+        .collect();
 
     location::update_driver_location_by_token(
         Token(token),
@@ -137,7 +142,7 @@ pub async fn update_driver_location(
         group_id,
         group_id2,
         req_merchant_id,
-        is_forwarded_request,
+        req_headers,
     )
     .await?;
     Ok(HttpResponse::Ok().finish())

--- a/crates/location_tracking_service/src/environment.rs
+++ b/crates/location_tracking_service/src/environment.rs
@@ -7,7 +7,7 @@
 */
 #![allow(clippy::expect_used)]
 
-use std::{env::var, sync::Arc};
+use std::{env::var, str::FromStr, sync::Arc};
 
 use chrono::NaiveTime;
 use rdkafka::{
@@ -114,6 +114,14 @@ pub struct AppConfig {
     /// tail. Defaults to 1800 (30 minutes).
     #[serde(default = "default_special_location_entry_ts_ttl")]
     pub special_location_entry_ts_ttl_sec: u64,
+    /// Cloud this LTS deployment runs in ("AWS" / "GCP"). Absent or
+    /// unparseable => UNAVAILABLE (cross-cloud forwarding disabled).
+    #[serde(default)]
+    pub cloud_type: Option<String>,
+    /// Cloud name -> base URL of that cloud's LTS deployment, used to
+    /// forward driver location updates to the owning cloud.
+    #[serde(default)]
+    pub cloud_lts_url_mapping: Option<HashMap<String, String>>,
 }
 
 fn default_queue_expiry() -> u64 {
@@ -256,6 +264,8 @@ pub struct AppState {
     pub queue_exit_hysteresis_threshold: u32,
     pub enable_queue_cache_empty_guard: bool,
     pub special_location_entry_ts_ttl_sec: u64,
+    pub cloud_type: CloudType,
+    pub cloud_lts_url_mapping: HashMap<CloudType, Url>,
 }
 
 impl AppState {
@@ -472,6 +482,37 @@ impl AppState {
         let detection_violation_config = app_config.detection_violation_config;
         let detection_anti_violation_config = app_config.detection_anti_violation_config;
 
+        let cloud_type = match app_config.cloud_type.as_deref() {
+            Some(cloud_type_str) => CloudType::from_str(cloud_type_str).unwrap_or_else(|_| {
+                error!(
+                    tag = "[Cloud Type]",
+                    "Failed to parse cloud_type '{}', defaulting to UNAVAILABLE", cloud_type_str
+                );
+                CloudType::UNAVAILABLE
+            }),
+            None => CloudType::UNAVAILABLE,
+        };
+
+        let cloud_lts_url_mapping: HashMap<CloudType, Url> = app_config
+            .cloud_lts_url_mapping
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(
+                |(cloud, url)| match (CloudType::from_str(&cloud), Url::parse(&url)) {
+                    (Ok(cloud), Ok(url)) => Some((cloud, url)),
+                    _ => {
+                        error!(
+                            tag = "[Cloud LTS Url Mapping]",
+                            "Skipping invalid cloud_lts_url_mapping entry: '{}' -> '{}'",
+                            cloud,
+                            url
+                        );
+                        None
+                    }
+                },
+            )
+            .collect();
+
         AppState {
             redis,
             secondary_redis,
@@ -550,6 +591,8 @@ impl AppState {
             queue_exit_hysteresis_threshold: app_config.queue_exit_hysteresis_threshold,
             enable_queue_cache_empty_guard: app_config.enable_queue_cache_empty_guard,
             special_location_entry_ts_ttl_sec: app_config.special_location_entry_ts_ttl_sec,
+            cloud_type,
+            cloud_lts_url_mapping,
         }
     }
 

--- a/crates/location_tracking_service/src/outbound/external.rs
+++ b/crates/location_tracking_service/src/outbound/external.rs
@@ -8,6 +8,7 @@
 use super::types::*;
 use crate::common::types::*;
 use crate::domain::types::internal::ride::ExternalReauthResponse;
+use crate::domain::types::ui::location::UpdateDriverLocationRequest;
 use crate::tools::error::AppError;
 use actix_http::StatusCode;
 use reqwest::{Method, Url};
@@ -121,6 +122,63 @@ pub async fn authenticate_bap(
         }),
     )
     .await
+}
+
+/// Forwards a driver location update batch to the LTS deployment of another
+/// cloud (the one owning the driver's merchant, per auth `cloudType`).
+///
+/// The request is replayed against `<base_url>/ui/driver/location` with the
+/// same `token`/`vt`/`dm` (and optional `mid`/`gid`/`gid2`) headers, plus an
+/// `x-forwarded-from-cloud: true` loop guard so the receiving cloud always
+/// processes it locally.
+#[allow(clippy::too_many_arguments)]
+pub async fn forward_driver_location_to_cloud(
+    base_url: &Url,
+    token: &str,
+    vehicle_type: &VehicleType,
+    driver_mode: &DriverMode,
+    merchant_id: Option<&MerchantId>,
+    group_id: Option<&str>,
+    group_id2: Option<&str>,
+    locations: &Vec<UpdateDriverLocationRequest>,
+) -> Result<(), AppError> {
+    let url = format!(
+        "{}/ui/driver/location",
+        base_url.as_str().trim_end_matches('/')
+    );
+    let url = Url::parse(&url)
+        .map_err(|e| AppError::InvalidRequest(format!("Invalid forward URL: {}", e)))?;
+
+    let vehicle_type = vehicle_type.to_string();
+    let driver_mode = driver_mode.to_string();
+
+    let mut headers: Vec<(&str, &str)> = vec![
+        ("content-type", "application/json"),
+        ("token", token),
+        ("vt", vehicle_type.as_str()),
+        ("dm", driver_mode.as_str()),
+        ("x-forwarded-from-cloud", "true"),
+    ];
+    if let Some(MerchantId(merchant_id)) = merchant_id {
+        headers.push(("mid", merchant_id.as_str()));
+    }
+    if let Some(group_id) = group_id {
+        headers.push(("gid", group_id));
+    }
+    if let Some(group_id2) = group_id2 {
+        headers.push(("gid2", group_id2));
+    }
+
+    call_api::<(), Vec<UpdateDriverLocationRequest>>(
+        Protocol::Http1,
+        Method::POST,
+        &url,
+        headers,
+        Some(locations.to_owned()),
+        Some("cross-cloud-forward"),
+    )
+    .await
+    .map_err(|e| e.into())
 }
 
 /// Sends a bulk location update to the `dobpp` endpoint.

--- a/crates/location_tracking_service/src/outbound/external.rs
+++ b/crates/location_tracking_service/src/outbound/external.rs
@@ -124,22 +124,31 @@ pub async fn authenticate_bap(
     .await
 }
 
+/// Hop-by-hop / connection-level headers that must not be replayed when
+/// forwarding a request; the HTTP client computes its own values for these.
+const NON_FORWARDABLE_HEADERS: [&str; 9] = [
+    "host",
+    "content-length",
+    "connection",
+    "keep-alive",
+    "transfer-encoding",
+    "upgrade",
+    "te",
+    "trailer",
+    "proxy-authorization",
+];
+
 /// Forwards a driver location update batch to the LTS deployment of another
 /// cloud (the one owning the driver's merchant, per auth `cloudType`).
 ///
-/// The request is replayed against `<base_url>/ui/driver/location` with the
-/// same `token`/`vt`/`dm` (and optional `mid`/`gid`/`gid2`) headers, plus an
+/// The request is replayed against `<base_url>/ui/driver/location` with all
+/// original request headers passed through unchanged (so headers added to
+/// this API in the future are never silently dropped), plus an appended
 /// `x-forwarded-from-cloud: true` loop guard so the receiving cloud always
 /// processes it locally.
-#[allow(clippy::too_many_arguments)]
 pub async fn forward_driver_location_to_cloud(
     base_url: &Url,
-    token: &str,
-    vehicle_type: &VehicleType,
-    driver_mode: &DriverMode,
-    merchant_id: Option<&MerchantId>,
-    group_id: Option<&str>,
-    group_id2: Option<&str>,
+    req_headers: &[(String, String)],
     locations: &Vec<UpdateDriverLocationRequest>,
 ) -> Result<(), AppError> {
     let url = format!(
@@ -149,25 +158,15 @@ pub async fn forward_driver_location_to_cloud(
     let url = Url::parse(&url)
         .map_err(|e| AppError::InvalidRequest(format!("Invalid forward URL: {}", e)))?;
 
-    let vehicle_type = vehicle_type.to_string();
-    let driver_mode = driver_mode.to_string();
-
-    let mut headers: Vec<(&str, &str)> = vec![
-        ("content-type", "application/json"),
-        ("token", token),
-        ("vt", vehicle_type.as_str()),
-        ("dm", driver_mode.as_str()),
-        ("x-forwarded-from-cloud", "true"),
-    ];
-    if let Some(MerchantId(merchant_id)) = merchant_id {
-        headers.push(("mid", merchant_id.as_str()));
-    }
-    if let Some(group_id) = group_id {
-        headers.push(("gid", group_id));
-    }
-    if let Some(group_id2) = group_id2 {
-        headers.push(("gid2", group_id2));
-    }
+    let mut headers: Vec<(&str, &str)> = req_headers
+        .iter()
+        .filter(|(name, _)| {
+            !NON_FORWARDABLE_HEADERS.contains(&name.to_lowercase().as_str())
+                && !name.eq_ignore_ascii_case("x-forwarded-from-cloud")
+        })
+        .map(|(name, value)| (name.as_str(), value.as_str()))
+        .collect();
+    headers.push(("x-forwarded-from-cloud", "true"));
 
     call_api::<(), Vec<UpdateDriverLocationRequest>>(
         Protocol::Http1,

--- a/crates/location_tracking_service/src/outbound/types.rs
+++ b/crates/location_tracking_service/src/outbound/types.rs
@@ -43,6 +43,9 @@ pub struct AuthResponseData {
     pub driver_id: DriverId,
     pub merchant_id: MerchantId,
     pub merchant_operating_city_id: MerchantOperatingCityId,
+    /// JSON key `cloudType`; optional so older driver-app responses still deserialize.
+    #[serde(default)]
+    pub cloud_type: Option<CloudType>,
 }
 
 // BAP Authentication (rider). BAP sends "riderId" in JSON; we expose as person_id.

--- a/crates/location_tracking_service/src/redis/commands.rs
+++ b/crates/location_tracking_service/src/redis/commands.rs
@@ -717,11 +717,13 @@ pub async fn set_driver_id(
     driver_id: DriverId,
     merchant_id: MerchantId,
     merchant_operating_city_id: MerchantOperatingCityId,
+    cloud_type: Option<CloudType>,
 ) -> Result<(), AppError> {
     let auth_data = AuthData {
         driver_id,
         merchant_id,
         merchant_operating_city_id,
+        cloud_type,
     };
     redis
         .set_key(&set_driver_id_key(token), auth_data, *auth_token_expiry)

--- a/dhall-configs/dev/location_tracking_service.dhall
+++ b/dhall-configs/dev/location_tracking_service.dhall
@@ -534,5 +534,9 @@ in {
     enable_special_location_bucketing = False,
     queue_position_range_offset = 2,
     queue_exit_hysteresis_threshold = 3,
-    enable_queue_cache_empty_guard = True
+    enable_queue_cache_empty_guard = True,
+    cloud_type = Some "AWS",
+    cloud_lts_url_mapping = Some (toMap {
+      GCP = "http://localhost:8081"
+    })
 }


### PR DESCRIPTION
## Description

Propagates nammayatri/nammayatri#16121 (driver-app internal auth now returns the merchant's `cloudType`) into LTS: driver location updates are routed to the LTS deployment of the cloud that owns the merchant.

### Routing rule (in `update_driver_location_by_token`, right after auth)
- Received `cloudType` matches the cloud this LTS runs in, or is absent/`UNAVAILABLE` → process locally (current behavior).
- Received `cloudType` differs → look up the owning cloud's LTS base URL in the new `cloud_lts_url_mapping` dhall config:
  - entry found → forward the original request (same body + `token`/`vt`/`dm`/`mid`/`gid`/`gid2` headers) to `<url>/ui/driver/location` and return its result
  - no entry → process locally
- Forwarded requests carry `x-forwarded-from-cloud: true`; the receiving LTS then always processes locally, so misconfigured clouds can't bounce a request in a loop.

### Details
- New `CloudType` enum (`AWS | GCP | UNAVAILABLE`) mirroring `Kernel.Types.Version.CloudType`.
- `cloudType` is cached with the token auth data in Redis (`#[serde(default)]` keeps pre-existing cached entries deserializable), so routing adds no extra auth calls on cache hits.
- New dhall fields `cloud_type` (cloud this deployment runs in) and `cloud_lts_url_mapping` (cloud → LTS base URL). Both optional — deployments without them keep current behavior.
- Bus-crew and DEV paths unchanged (always local).

### Rollout notes
- Prod/UAT dhall configs need per-cloud values (`cloud_type` + peer-cloud URLs in the map); dev config carries placeholders.
- Requires nammayatri/nammayatri#16121 deployed on the driver-app side; until then `cloudType` is absent and everything processes locally.
- Cached tokens pick up `cloudType` on re-auth as `auth_token_expiry` TTLs roll over.

## How did you test it?
- `cargo check` clean, `cargo clippy --all-targets` introduces no new warnings, `cargo fmt` no-op, dhall dev config evaluates with the `dhall` CLI. Pre-commit hooks (clippy, treefmt, trailing-ws, gpl-header) pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cloud deployment awareness for AWS and GCP environments.
  * Driver location updates can now be securely routed to the appropriate cloud.
  * Added safeguards to prevent repeated forwarding between cloud environments.
  * Added optional cloud metadata to authentication and driver records.
* **Configuration**
  * Added settings for the active cloud and cross-cloud service endpoints.
  * Invalid or missing cloud settings now safely default to unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->