### PR TITLE
enh: added preserve_position for manualQueueRemove

### DIFF
--- a/crates/location_tracking_service/src/domain/action/internal/location.rs
+++ b/crates/location_tracking_service/src/domain/action/internal/location.rs
@@ -678,6 +678,7 @@ pub async fn manual_queue_remove(
     merchant_id: String,
     driver_id: String,
     reason: Option<String>,
+    preserve_position: bool,
 ) -> Result<APISuccess, AppError> {
     let primary_redis = data.queue_redis();
     remove_driver_from_queue(
@@ -688,6 +689,24 @@ pub async fn manual_queue_remove(
     )
     .await?;
     delete_driver_queue_tracking(&primary_redis, &merchant_id, &driver_id).await?;
+    // Hard removal (preserve_position = false): also drop `last_ts` so a
+    // subsequent in-fence ping can't restore the driver's original rank via the
+    // drainer's stored-ts ZADD — the re-entry restarts fresh at the tail.
+    // Preserved by default to keep the grace re-entry window. Best-effort — a
+    // failure here only weakens position-reset, so it shouldn't fail the
+    // removal that already succeeded above.
+    if !preserve_position {
+        if let Err(err) = delete_driver_queue_last_ts(
+            &primary_redis,
+            &special_location_id,
+            &vehicle_type,
+            &driver_id,
+        )
+        .await
+        {
+            error!(tag = "[Manual Queue Remove Reset Position]", error = %err);
+        }
+    }
     // Normalize once: empty/whitespace-only reasons collapse to None so the
     // rank-history event and the prometheus label stay in sync.
     let normalized_reason = reason.as_deref().map(str::trim).filter(|r| !r.is_empty());

--- a/crates/location_tracking_service/src/domain/api/internal/location.rs
+++ b/crates/location_tracking_service/src/domain/api/internal/location.rs
@@ -155,7 +155,13 @@ async fn manual_queue_remove(
     body: Option<Json<ManualQueueRemoveRequest>>,
 ) -> Result<Json<APISuccess>, AppError> {
     let (special_location_id, vehicle_type, merchant_id, driver_id) = path.into_inner();
-    let reason = body.and_then(|b| b.into_inner().reason);
+    // Absent body or absent field → preserve position (soft removal).
+    let (reason, preserve_position) = body
+        .map(|b| {
+            let b = b.into_inner();
+            (b.reason, b.preserve_position.unwrap_or(true))
+        })
+        .unwrap_or((None, true));
     Ok(Json(
         location::manual_queue_remove(
             data,
@@ -164,6 +170,7 @@ async fn manual_queue_remove(
             merchant_id,
             driver_id,
             reason,
+            preserve_position,
         )
         .await?,
     ))

--- a/crates/location_tracking_service/src/domain/types/internal/location.rs
+++ b/crates/location_tracking_service/src/domain/types/internal/location.rs
@@ -147,10 +147,18 @@ pub struct ManualQueueAddRequest {
 /// send a body get `exit:manual` in the rank-history hash; callers that do
 /// get `exit:manual:<reason>` so the timeline shows *why* the operator pulled
 /// the driver (e.g. wrong queue, complaint, fraud).
+///
+/// `preserve_position` controls whether the driver keeps their queue position.
+/// Optional and defaults to `true` (absent → preserve): the removal leaves
+/// `last_ts` intact, so a driver still pinging in-fence is re-added at their
+/// original rank within its TTL — a "soft" removal. Set it to `false` for a
+/// hard removal that also deletes `last_ts`, so a re-entry restarts fresh at
+/// the tail of the queue.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ManualQueueRemoveRequest {
     pub reason: Option<String>,
+    pub preserve_position: Option<bool>,
 }
 
 /// One event from the per-driver rank-history list. `value` is the raw event


### PR DESCRIPTION
Added queue_preserve param for manualQueueRemove endpoint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to preserve or reset a driver’s queue position when manually removing them.
  * Soft removal preserves the driver’s current position for re-entry.
  * Hard removal resets the queue position, allowing re-entry at the end of the queue.
  * The position-preserving behavior is used by default when no option is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->