### PR TITLE
fix: relay cross-cloud peer status instead of collapsing to 500

### DIFF
--- a/crates/location_tracking_service/src/outbound/external.rs
+++ b/crates/location_tracking_service/src/outbound/external.rs
@@ -9,12 +9,13 @@ use super::types::*;
 use crate::common::types::*;
 use crate::domain::types::internal::ride::ExternalReauthResponse;
 use crate::domain::types::ui::location::UpdateDriverLocationRequest;
-use crate::tools::error::AppError;
+use crate::tools::error::{AppError, ErrorBody};
 use actix_http::StatusCode;
 use reqwest::{Method, Url};
 use serde::{Deserialize, Serialize};
 use shared::tools::callapi::{call_api, call_api_unwrapping_error, Protocol};
 use std::collections::HashMap;
+use tracing::error;
 
 /// Authenticates a driver using the `dobpp` method.
 ///
@@ -168,16 +169,43 @@ pub async fn forward_driver_location_to_cloud(
         .collect();
     headers.push(("x-forwarded-from-cloud", "true"));
 
-    call_api::<(), Vec<UpdateDriverLocationRequest>>(
+    call_api_unwrapping_error::<(), Vec<UpdateDriverLocationRequest>, AppError>(
         Protocol::Http1,
         Method::POST,
         &url,
         headers,
         Some(locations.to_owned()),
         Some("cross-cloud-forward"),
+        Box::new(|resp| {
+            Box::pin(async move {
+                let status = resp.status().as_u16();
+                match resp.json::<ErrorBody>().await {
+                    Ok(body) => {
+                        error!(
+                            tag = "[CROSS CLOUD FORWARD - PEER ERROR]",
+                            peer_status = status,
+                            peer_error_code = %body.error_code,
+                            peer_error_message = %body.error_message,
+                        );
+                        AppError::ForwardedCloudError(status, body.error_code, body.error_message)
+                    }
+                    Err(err) => {
+                        error!(
+                            tag = "[CROSS CLOUD FORWARD - PEER ERROR]",
+                            peer_status = status,
+                            body_parse_error = %err,
+                        );
+                        AppError::ForwardedCloudError(
+                            status,
+                            "FORWARDED_CLOUD_ERROR".to_string(),
+                            String::new(),
+                        )
+                    }
+                }
+            })
+        }),
     )
     .await
-    .map_err(|e| e.into())
 }
 
 /// Sends a bulk location update to the `dobpp` endpoint.

--- a/crates/location_tracking_service/src/tools/error.rs
+++ b/crates/location_tracking_service/src/tools/error.rs
@@ -16,7 +16,7 @@ use shared::tools::callapi::CallAPIError;
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ErrorBody {
-    error_message: String,
+    pub error_message: String,
     pub error_code: String,
 }
 
@@ -55,6 +55,7 @@ pub enum AppError {
     TraceTokenExpired,
     RiderAuthFailed,
     RiderLocationNotFound,
+    ForwardedCloudError(u16, String, String),
 }
 
 impl AppError {
@@ -101,6 +102,7 @@ impl AppError {
             }
             AppError::RiderAuthFailed => "Rider authentication failed".to_string(),
             AppError::RiderLocationNotFound => "Rider location not found".to_string(),
+            AppError::ForwardedCloudError(_, _, error_message) => error_message.to_string(),
             _ => "Some Error Occured".to_string(),
         }
     }
@@ -142,6 +144,7 @@ impl AppError {
             AppError::TraceTokenExpired => "TRACE_TOKEN_EXPIRED",
             AppError::RiderAuthFailed => "RIDER_AUTH_FAILED",
             AppError::RiderLocationNotFound => "RIDER_LOCATION_NOT_FOUND",
+            AppError::ForwardedCloudError(_, error_code, _) => error_code.as_str(),
         }
         .to_string()
     }
@@ -189,6 +192,9 @@ impl ResponseError for AppError {
             AppError::TraceTokenExpired => StatusCode::UNAUTHORIZED,
             AppError::RiderAuthFailed => StatusCode::UNAUTHORIZED,
             AppError::RiderLocationNotFound => StatusCode::NOT_FOUND,
+            AppError::ForwardedCloudError(status, _, _) => {
+                StatusCode::from_u16(*status).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR)
+            }
         }
     }
 }


### PR DESCRIPTION
## Problem

When a driver's merchant is owned by another cloud, LTS forwards the location batch to that cloud's LTS. The peer answers with an ordinary `400` or `429`, and we return **500** to the driver app.

`forward_driver_location_to_cloud` used plain `call_api`, which maps every non-2xx into a single error variant:

```rust
// shared-kernel-rs @ 09197c6, crates/shared/src/tools/callapi.rs
} else {
    let resp_status = resp.status().to_string();
    Err(CallAPIError::ExternalAPICallError(resp_status))   // status → a string
}
```

→ `From<CallAPIError> for AppError` → `AppError::ExternalAPICallError` → `INTERNAL_SERVER_ERROR`.

Two places in this codebase already do it correctly: `authenticate_dobpp` (same file) uses `call_api_unwrapping_error` with a status-aware handler, and the Haskell proxy `Utils/Common/CrossCloudProxy.hs` relays `Http.responseStatus` verbatim. The Rust forwarder was the outlier.

## Impact

The driver app retries 5xx and discards 4xx (`LocationUpdateService.java:1366`):

```java
boolean shouldRetry = retry && (respCode < 400 || respCode >= 500);
```

So each mislabelled 4xx was **re-queued and resent**, amplifying load against a peer that was never going to accept the batch.

The app also drives a serviceability banner off `errorCode` (`checkLocationApiResponse`, keyed on `LOCATION_NOT_SERVICEABLE`). Because we returned 500 with `EXTERNAL_APICALL_ERROR`, that branch never fired and affected drivers saw a generic failure instead of "outside the service area".

## Change

**`outbound/external.rs`** — `call_api` → `call_api_unwrapping_error` with a handler that reads the peer's status and `ErrorBody`, plus an explicit `[CROSS CLOUD FORWARD - PEER ERROR]` log.

**`tools/error.rs`** — new `AppError::ForwardedCloudError(u16, String, String)` carrying the peer's status, `errorCode` and `errorMessage`. `status_code()` returns `StatusCode::from_u16(status)`, `code()` returns the peer's own code.

The peer's `errorCode` is relayed, not just the status, because the mapping is many-to-one — `LOCATION_NOT_SERVICEABLE`, `TOKEN_EXPIRED`, `INVALID_REQUEST` and `DRIVER_RIDE_DETAILS_NOT_FOUND` are all `400`. Collapsing them would break the app's error handling and the serviceability banner.

## Behaviour

| Peer returns | Before | After |
|---|---|---|
| `400 LOCATION_NOT_SERVICEABLE` | 500 `EXTERNAL_APICALL_ERROR` | `400 LOCATION_NOT_SERVICEABLE` |
| `429 HITS_LIMIT_EXCEED` | 500 `EXTERNAL_APICALL_ERROR` | `429 HITS_LIMIT_EXCEED` |
| `403 DRIVER_BLOCKED` | 500 `EXTERNAL_APICALL_ERROR` | `403 DRIVER_BLOCKED` |
| no response (timeout / reset) | 500 | **500 — unchanged** |

Transport failures never reach the handler and stay `ExternalAPICallError` → 500. A peer that never answered is a genuine server-side failure and should keep alerting.

## Why the added log

`call_api_unwrapping_error` logs the response *without* its body, unlike `call_api` which logged `response_body`. That body is currently the only place the peer's diagnostic detail (e.g. the unserviceable lat/lon) is visible on this side of the hop. The new log line preserves it as structured fields — `peer_status`, `peer_error_code`, `peer_error_message` — which are queryable rather than buried in a serialized blob.

## Note for dashboards

`response_code` in logs and metrics is the thiserror `Display` (the variant name), not `code()`. These responses will now appear as `FORWARDED_CLOUD_ERROR` with the correct `response_status`; the peer's real code is in the new log line and in the response body. Anything filtering on `response_code: "EXTERNAL_APICALL_ERROR"` for this path will see a drop.

## Testing

- `cargo check -p location_tracking_service` — clean
- `cargo fmt --check` — clean
- `cargo clippy --all-targets` — clean (4 pre-existing warnings elsewhere, none in changed files)
- Peer error body shape verified against the deployed peer build: same `ErrorBody` struct, same `#[serde(rename_all = "camelCase")]`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when forwarding location updates across cloud environments.
  * Preserved detailed error messages and status codes from the receiving service.
  * Added a safe fallback response when a forwarded error’s status is invalid or unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->