### PR TITLE
perf: reuse a long-lived HTTP client for cross-cloud forwards

### DIFF
--- a/crates/location_tracking_service/src/domain/action/ui/location.rs
+++ b/crates/location_tracking_service/src/domain/action/ui/location.rs
@@ -337,7 +337,13 @@ pub async fn update_driver_location_by_token(
                         cloud,
                         data.cloud_type
                     );
-                    forward_driver_location_to_cloud(url, &req_headers, &locations).await?;
+                    forward_driver_location_to_cloud(
+                        &data.forward_client,
+                        url,
+                        &req_headers,
+                        &locations,
+                    )
+                    .await?;
                     return Ok(HttpResponse::Ok().finish());
                 }
             }

--- a/crates/location_tracking_service/src/environment.rs
+++ b/crates/location_tracking_service/src/environment.rs
@@ -598,7 +598,16 @@ impl AppState {
             special_location_entry_ts_ttl_sec: app_config.special_location_entry_ts_ttl_sec,
             cloud_type,
             cloud_lts_url_mapping,
-            forward_client: reqwest::Client::new(),
+            // Pool settings mirror the ERSS provider client. pool_idle_timeout
+            // stays below typical LB idle timeouts (~60s) so a forward never
+            // picks up a connection the peer's load balancer already closed.
+            // No request timeout here: the RequestTimeout middleware already
+            // bounds the whole request, forward included.
+            forward_client: reqwest::Client::builder()
+                .pool_max_idle_per_host(10)
+                .pool_idle_timeout(std::time::Duration::from_secs(30))
+                .build()
+                .unwrap_or_default(),
         }
     }
 

--- a/crates/location_tracking_service/src/environment.rs
+++ b/crates/location_tracking_service/src/environment.rs
@@ -266,6 +266,11 @@ pub struct AppState {
     pub special_location_entry_ts_ttl_sec: u64,
     pub cloud_type: CloudType,
     pub cloud_lts_url_mapping: HashMap<CloudType, Url>,
+    /// Long-lived HTTP client for cross-cloud forwards. Built once at startup
+    /// so forwards reuse pooled connections instead of paying a client build
+    /// plus TCP/TLS handshake on every driver ping (reqwest::Client is a
+    /// cheap Arc handle to clone).
+    pub forward_client: reqwest::Client,
 }
 
 impl AppState {
@@ -593,6 +598,7 @@ impl AppState {
             special_location_entry_ts_ttl_sec: app_config.special_location_entry_ts_ttl_sec,
             cloud_type,
             cloud_lts_url_mapping,
+            forward_client: reqwest::Client::new(),
         }
     }
 

--- a/crates/location_tracking_service/src/outbound/external.rs
+++ b/crates/location_tracking_service/src/outbound/external.rs
@@ -13,7 +13,7 @@ use crate::tools::error::{AppError, ErrorBody};
 use actix_http::StatusCode;
 use reqwest::{Method, Url};
 use serde::{Deserialize, Serialize};
-use shared::tools::callapi::{call_api, call_api_unwrapping_error, Protocol};
+use shared::tools::callapi::{call_api, call_api_unwrapping_error, call_api_with_client, Protocol};
 use std::collections::HashMap;
 use tracing::error;
 
@@ -148,6 +148,7 @@ const NON_FORWARDABLE_HEADERS: [&str; 9] = [
 /// `x-forwarded-from-cloud: true` loop guard so the receiving cloud always
 /// processes it locally.
 pub async fn forward_driver_location_to_cloud(
+    client: &reqwest::Client,
     base_url: &Url,
     req_headers: &[(String, String)],
     locations: &Vec<UpdateDriverLocationRequest>,
@@ -169,8 +170,12 @@ pub async fn forward_driver_location_to_cloud(
         .collect();
     headers.push(("x-forwarded-from-cloud", "true"));
 
-    call_api_unwrapping_error::<(), Vec<UpdateDriverLocationRequest>, AppError>(
-        Protocol::Http1,
+    // Long-lived client from AppState: call_api/call_api_unwrapping_error
+    // build a fresh reqwest::Client (a new connection pool) per call, which
+    // costs a TCP/TLS handshake on every forwarded ping; this reuses pooled
+    // connections instead.
+    call_api_with_client::<(), Vec<UpdateDriverLocationRequest>, AppError>(
+        client,
         Method::POST,
         &url,
         headers,


### PR DESCRIPTION
## Description

`call_api`/`call_api_unwrapping_error` construct a fresh `reqwest::Client` — a brand-new connection pool — on every invocation, so each cross-cloud forwarded driver ping paid client construction plus a full TCP/TLS handshake to the peer cloud.

This builds one `reqwest::Client` at startup (`AppState.forward_client`) and routes the forward through the shared kernel's `call_api_with_client`, which is the exact same code path `call_api_unwrapping_error` uses internally — identical metrics (`CALL_EXTERNAL_API`), logging, and the #252 `ForwardedCloudError` peer-status relay — just with pooled, kept-alive connections.

## How did you test it?

Full local regression with a mock auth service, mock peer LTS, and two real LTS instances (AWS/GCP configs) against throwaway redis:

**Routing matrix** — cross-cloud forwards once; same-cloud / missing cloudType / spoofed guard all process locally; cache-hit forwards skip re-auth.
**Header & body fidelity** — all headers incl. unknown future ones pass through, guard appended exactly once, body values intact.
**#252 error relay** — peer 400 + ErrorBody → driver gets 400 with peer's errorCode/errorMessage; peer 503 non-ErrorBody → 503 `FORWARDED_CLOUD_ERROR`; peer down → 500; instant recovery; local traffic isolated throughout.
**Loop safety** — bidirectional forwarding between two real instances (exactly one hop each way); adversarial ping-pong topology (misconfigured peer mapping traffic back) still processes locally via the `x-forwarded-from-cloud` guard.
**Concurrency & pooling** — 30 parallel forwards: 30/30 success over 10 pooled connections; 10 sequential forwards reuse a single TCP connection (verified by client source port at the peer).
**Bounded latency** — LTS's own `RequestTimeout` middleware (`request_timeout` config) caps total request time including the forward, so a slow peer cannot hold connections indefinitely.

## Checklist

- [x] I formatted the code and addressed linter errors
- [x] I reviewed submitted code
- [x] I tested the changes using local integration testing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved cross-cloud driver location forwarding for more consistent and efficient request handling.
  * Preserved existing forwarding behavior, including request details, loop protection, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->